### PR TITLE
feat: init backend maven multi-module structure, closes #1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,25 @@ name: CI
   pull_request:
 
 jobs:
+  backend-build:
+    name: Backend Maven build and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Build and test all backend modules
+        working-directory: backend
+        run: mvn -B -ntp verify
+
   skeleton:
     name: Skeleton build checks
     runs-on: ubuntu-latest

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,15 @@
-FROM eclipse-temurin:21-jdk-jammy
+FROM maven:3.9.9-eclipse-temurin-21 AS build
+
+WORKDIR /workspace
+
+COPY . .
+RUN mvn -pl common -am package -DskipTests
+
+FROM eclipse-temurin:21-jre-jammy
 
 WORKDIR /opt/app
 
-RUN mkdir -p /opt/app/public/actuator /opt/app/public/api/v1 /opt/app/public/hls \
-    && printf '{"status":"UP","service":"backend-skeleton"}\n' > /opt/app/public/actuator/health \
-    && printf 'VoD backend skeleton. Business API implementation is deferred.\n' > /opt/app/public/api/v1/index.html \
-    && printf '#EXTM3U\n# VoD HLS skeleton. Streaming implementation is deferred.\n' > /opt/app/public/hls/index.m3u8
+COPY --from=build /workspace/common/target/common-0.1.0-SNAPSHOT.jar /opt/app/backend.jar
 
 ENV SERVER_PORT=8080
 
@@ -14,4 +18,4 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
     CMD bash -c ": > /dev/tcp/127.0.0.1/${SERVER_PORT}" || exit 1
 
-CMD ["sh", "-c", "jwebserver -b 0.0.0.0 -p ${SERVER_PORT} -d /opt/app/public"]
+CMD ["java", "-jar", "/opt/app/backend.jar"]

--- a/backend/auth/pom.xml
+++ b/backend/auth/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vodplatform</groupId>
+        <artifactId>backend</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>auth</artifactId>
+    <name>vod-backend-auth</name>
+</project>

--- a/backend/auth/src/main/java/com/vodplatform/auth/package-info.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/package-info.java
@@ -1,0 +1,1 @@
+package com.vodplatform.auth;

--- a/backend/catalog/pom.xml
+++ b/backend/catalog/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vodplatform</groupId>
+        <artifactId>backend</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>catalog</artifactId>
+    <name>vod-backend-catalog</name>
+</project>

--- a/backend/catalog/src/main/java/com/vodplatform/catalog/package-info.java
+++ b/backend/catalog/src/main/java/com/vodplatform/catalog/package-info.java
@@ -1,0 +1,1 @@
+package com.vodplatform.catalog;

--- a/backend/common/pom.xml
+++ b/backend/common/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vodplatform</groupId>
+        <artifactId>backend</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>common</artifactId>
+    <name>vod-backend-common</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.vodplatform.common.VodBackendApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/common/src/main/java/com/vodplatform/common/VodBackendApplication.java
+++ b/backend/common/src/main/java/com/vodplatform/common/VodBackendApplication.java
@@ -1,0 +1,17 @@
+package com.vodplatform.common;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = "com.vodplatform")
+public class VodBackendApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(VodBackendApplication.class);
+
+    public static void main(String[] args) {
+        SpringApplication.run(VodBackendApplication.class, args);
+        log.info("VoD backend skeleton started");
+    }
+}

--- a/backend/common/src/main/resources/application.yml
+++ b/backend/common/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+server:
+  port: ${SERVER_PORT:8080}
+
+spring:
+  application:
+    name: vod-backend
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+
+logging:
+  pattern:
+    console: "%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5level [%thread] %logger{36} - %msg%n"

--- a/backend/common/src/test/java/com/vodplatform/common/VodBackendApplicationTests.java
+++ b/backend/common/src/test/java/com/vodplatform/common/VodBackendApplicationTests.java
@@ -1,0 +1,34 @@
+package com.vodplatform.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class VodBackendApplicationTests {
+
+    private final TestRestTemplate restTemplate;
+    private final int port;
+
+    @Autowired
+    VodBackendApplicationTests(TestRestTemplate restTemplate, @LocalServerPort int port) {
+        this.restTemplate = restTemplate;
+        this.port = port;
+    }
+
+    @Test
+    void actuatorHealthReturnsOk() {
+        ResponseEntity<String> response = restTemplate.getForEntity(
+                "http://localhost:%d/actuator/health".formatted(port),
+                String.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+}

--- a/backend/encoding/pom.xml
+++ b/backend/encoding/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vodplatform</groupId>
+        <artifactId>backend</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>encoding</artifactId>
+    <name>vod-backend-encoding</name>
+</project>

--- a/backend/encoding/src/main/java/com/vodplatform/encoding/package-info.java
+++ b/backend/encoding/src/main/java/com/vodplatform/encoding/package-info.java
@@ -1,0 +1,1 @@
+package com.vodplatform.encoding;

--- a/backend/library/pom.xml
+++ b/backend/library/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vodplatform</groupId>
+        <artifactId>backend</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>library</artifactId>
+    <name>vod-backend-library</name>
+</project>

--- a/backend/library/src/main/java/com/vodplatform/library/package-info.java
+++ b/backend/library/src/main/java/com/vodplatform/library/package-info.java
@@ -1,0 +1,1 @@
+package com.vodplatform.library;

--- a/backend/playback/pom.xml
+++ b/backend/playback/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vodplatform</groupId>
+        <artifactId>backend</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>playback</artifactId>
+    <name>vod-backend-playback</name>
+</project>

--- a/backend/playback/src/main/java/com/vodplatform/playback/package-info.java
+++ b/backend/playback/src/main/java/com/vodplatform/playback/package-info.java
@@ -1,0 +1,1 @@
+package com.vodplatform.playback;

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.vodplatform</groupId>
+    <artifactId>backend</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>vod-backend</name>
+
+    <modules>
+        <module>auth</module>
+        <module>user</module>
+        <module>catalog</module>
+        <module>upload</module>
+        <module>encoding</module>
+        <module>playback</module>
+        <module>stream</module>
+        <module>progress</module>
+        <module>library</module>
+        <module>search</module>
+        <module>common</module>
+    </modules>
+
+    <properties>
+        <java.version>21</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/backend/progress/pom.xml
+++ b/backend/progress/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vodplatform</groupId>
+        <artifactId>backend</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>progress</artifactId>
+    <name>vod-backend-progress</name>
+</project>

--- a/backend/progress/src/main/java/com/vodplatform/progress/package-info.java
+++ b/backend/progress/src/main/java/com/vodplatform/progress/package-info.java
@@ -1,0 +1,1 @@
+package com.vodplatform.progress;

--- a/backend/search/pom.xml
+++ b/backend/search/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vodplatform</groupId>
+        <artifactId>backend</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>search</artifactId>
+    <name>vod-backend-search</name>
+</project>

--- a/backend/search/src/main/java/com/vodplatform/search/package-info.java
+++ b/backend/search/src/main/java/com/vodplatform/search/package-info.java
@@ -1,0 +1,1 @@
+package com.vodplatform.search;

--- a/backend/stream/pom.xml
+++ b/backend/stream/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vodplatform</groupId>
+        <artifactId>backend</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>stream</artifactId>
+    <name>vod-backend-stream</name>
+</project>

--- a/backend/stream/src/main/java/com/vodplatform/stream/package-info.java
+++ b/backend/stream/src/main/java/com/vodplatform/stream/package-info.java
@@ -1,0 +1,1 @@
+package com.vodplatform.stream;

--- a/backend/upload/pom.xml
+++ b/backend/upload/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vodplatform</groupId>
+        <artifactId>backend</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>upload</artifactId>
+    <name>vod-backend-upload</name>
+</project>

--- a/backend/upload/src/main/java/com/vodplatform/upload/package-info.java
+++ b/backend/upload/src/main/java/com/vodplatform/upload/package-info.java
@@ -1,0 +1,1 @@
+package com.vodplatform.upload;

--- a/backend/user/pom.xml
+++ b/backend/user/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vodplatform</groupId>
+        <artifactId>backend</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>user</artifactId>
+    <name>vod-backend-user</name>
+</project>

--- a/backend/user/src/main/java/com/vodplatform/user/package-info.java
+++ b/backend/user/src/main/java/com/vodplatform/user/package-info.java
@@ -1,0 +1,1 @@
+package com.vodplatform.user;


### PR DESCRIPTION
## Summary

Initialize the backend foundation for the Self-hosted VoD Platform using a Maven multi-module Spring Boot structure.

This PR sets up the backend project layout, adds placeholder domain modules, introduces a runnable Spring Boot skeleton application, updates the backend Docker image to run the packaged application, and adds CI validation for backend builds and tests.

Closes #1

## Changes

### Backend Maven multi-module structure

Added a parent Maven project under `backend/` with Java 21 and Spring Boot 3.3.5.

Created the following backend modules:

* `auth`
* `user`
* `catalog`
* `upload`
* `encoding`
* `playback`
* `stream`
* `progress`
* `library`
* `search`
* `common`

Each feature module currently contains a minimal package definition so the module structure is ready for future implementation.

### Spring Boot skeleton application

Added the initial runnable backend application in the `common` module:

* `VodBackendApplication`
* Spring Boot auto-configuration
* Package scanning across `com.vodplatform`
* Basic startup logging

Added application configuration:

* Server port defaults to `8080`
* Application name: `vod-backend`
* Actuator health endpoint exposed
* Console logging pattern configured

### Health check test

Added a Spring Boot integration test that verifies:

* The application starts successfully
* `/actuator/health` returns HTTP `200 OK`

### Docker backend runtime

Updated `backend/Dockerfile` from a static `jwebserver` placeholder to a real backend runtime image:

* Uses Maven + Eclipse Temurin 21 for the build stage
* Packages the `common` Spring Boot application
* Uses Eclipse Temurin 21 JRE for the runtime stage
* Runs the backend with:

```bash
java -jar /opt/app/backend.jar
```

### CI update

Added a backend CI job to `.github/workflows/ci.yml` that:

* Checks out the repository
* Sets up Java 21 using Temurin
* Enables Maven dependency caching
* Runs backend verification with:

```bash
cd backend
mvn -B -ntp verify
```

## How to test

Run the backend build and tests locally:

```bash
cd backend
mvn -B -ntp verify
```

Build the backend Docker image:

```bash
docker build -t vod-backend ./backend
```

Run the backend container:

```bash
docker run --rm -p 8080:8080 vod-backend
```

Verify health endpoint:

```bash
curl http://localhost:8080/actuator/health
```

Expected result:

```json
{
  "status": "UP"
}
```

## Notes

This PR only initializes the backend project skeleton. Business APIs, persistence, authentication logic, video upload, encoding, playback, streaming, search, and user-library features will be implemented in follow-up PRs.

## Checklist

* [x] Added Maven multi-module backend structure
* [x] Added Spring Boot skeleton application
* [x] Added backend health check endpoint
* [x] Added integration test for actuator health
* [x] Updated Dockerfile to run the packaged backend application
* [x] Added CI backend build and test job
