### PR TITLE
feat: init worker spring boot structure, closes #2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,25 @@ jobs:
         working-directory: backend
         run: mvn -B -ntp verify
 
+  worker-build:
+    name: Worker Maven build and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Build and test all worker modules
+        working-directory: worker
+        run: mvn -B -ntp verify
+
   skeleton:
     name: Skeleton build checks
     runs-on: ubuntu-latest

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,11 @@
-FROM eclipse-temurin:21-jdk-jammy
+FROM maven:3.9.9-eclipse-temurin-21 AS build
+
+WORKDIR /workspace
+
+COPY . .
+RUN mvn -pl queue -am package -DskipTests
+
+FROM eclipse-temurin:21-jre-jammy
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ffmpeg ca-certificates \
@@ -10,7 +17,17 @@ ENV FFMPEG_PATH=ffmpeg
 ENV FFPROBE_PATH=ffprobe
 ENV WORKER_CONCURRENCY=1
 ENV WORKER_TEMP_DIR=/tmp/vod-worker
+ENV SERVER_PORT=8081
 
-RUN ffmpeg -version >/dev/null && ffprobe -version >/dev/null
+RUN mkdir -p "${WORKER_TEMP_DIR}" \
+    && ffmpeg -version >/dev/null \
+    && ffprobe -version >/dev/null
 
-CMD ["sh", "-c", "echo 'VoD worker skeleton. Queue consumer and transcoding implementation are deferred.'; while true; do sleep 3600; done"]
+COPY --from=build /workspace/queue/target/queue-0.1.0-SNAPSHOT.jar /opt/worker/worker.jar
+
+EXPOSE 8081
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD bash -c ": > /dev/tcp/127.0.0.1/${SERVER_PORT}" || exit 1
+
+CMD ["java", "-jar", "/opt/worker/worker.jar"]

--- a/worker/cleanup/pom.xml
+++ b/worker/cleanup/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vodplatform.worker</groupId>
+        <artifactId>worker</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>cleanup</artifactId>
+    <name>vod-worker-cleanup</name>
+</project>

--- a/worker/cleanup/src/main/java/com/vodplatform/worker/cleanup/package-info.java
+++ b/worker/cleanup/src/main/java/com/vodplatform/worker/cleanup/package-info.java
@@ -1,0 +1,1 @@
+package com.vodplatform.worker.cleanup;

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.vodplatform.worker</groupId>
+    <artifactId>worker</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>vod-worker</name>
+
+    <modules>
+        <module>queue</module>
+        <module>probe</module>
+        <module>transcode</module>
+        <module>storage</module>
+        <module>status</module>
+        <module>cleanup</module>
+    </modules>
+
+    <properties>
+        <java.version>21</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/worker/probe/pom.xml
+++ b/worker/probe/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vodplatform.worker</groupId>
+        <artifactId>worker</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>probe</artifactId>
+    <name>vod-worker-probe</name>
+</project>

--- a/worker/probe/src/main/java/com/vodplatform/worker/probe/package-info.java
+++ b/worker/probe/src/main/java/com/vodplatform/worker/probe/package-info.java
@@ -1,0 +1,1 @@
+package com.vodplatform.worker.probe;

--- a/worker/queue/pom.xml
+++ b/worker/queue/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vodplatform.worker</groupId>
+        <artifactId>worker</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>queue</artifactId>
+    <name>vod-worker-queue</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.vodplatform.worker.queue.VodWorkerApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/worker/queue/src/main/java/com/vodplatform/worker/queue/VodWorkerApplication.java
+++ b/worker/queue/src/main/java/com/vodplatform/worker/queue/VodWorkerApplication.java
@@ -1,0 +1,37 @@
+package com.vodplatform.worker.queue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
+
+@SpringBootApplication(scanBasePackages = "com.vodplatform.worker")
+public class VodWorkerApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(VodWorkerApplication.class);
+
+    public static void main(String[] args) {
+        SpringApplication.run(VodWorkerApplication.class, args);
+    }
+
+    @Bean
+    ApplicationRunner workerStartupLogger(Environment environment) {
+        return new WorkerStartupLogger(environment);
+    }
+
+    private record WorkerStartupLogger(Environment environment) implements ApplicationRunner {
+
+        @Override
+        public void run(ApplicationArguments args) {
+            log.info(
+                    "VoD worker skeleton initialized; queue consumption disabled; ffmpegPath={}; ffprobePath={}",
+                    environment.getProperty("FFMPEG_PATH", "ffmpeg"),
+                    environment.getProperty("FFPROBE_PATH", "ffprobe")
+            );
+        }
+    }
+}

--- a/worker/queue/src/main/resources/application.yml
+++ b/worker/queue/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+server:
+  port: ${SERVER_PORT:8081}
+
+spring:
+  application:
+    name: vod-worker
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+
+logging:
+  pattern:
+    console: "%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5level [%thread] %logger{36} - %msg%n"

--- a/worker/queue/src/test/java/com/vodplatform/worker/queue/VodWorkerApplicationTests.java
+++ b/worker/queue/src/test/java/com/vodplatform/worker/queue/VodWorkerApplicationTests.java
@@ -1,0 +1,34 @@
+package com.vodplatform.worker.queue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class VodWorkerApplicationTests {
+
+    private final TestRestTemplate restTemplate;
+    private final int port;
+
+    @Autowired
+    VodWorkerApplicationTests(TestRestTemplate restTemplate, @LocalServerPort int port) {
+        this.restTemplate = restTemplate;
+        this.port = port;
+    }
+
+    @Test
+    void actuatorHealthReturnsOk() {
+        ResponseEntity<String> response = restTemplate.getForEntity(
+                "http://localhost:%d/actuator/health".formatted(port),
+                String.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+}

--- a/worker/status/pom.xml
+++ b/worker/status/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vodplatform.worker</groupId>
+        <artifactId>worker</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>status</artifactId>
+    <name>vod-worker-status</name>
+</project>

--- a/worker/status/src/main/java/com/vodplatform/worker/status/package-info.java
+++ b/worker/status/src/main/java/com/vodplatform/worker/status/package-info.java
@@ -1,0 +1,1 @@
+package com.vodplatform.worker.status;

--- a/worker/storage/pom.xml
+++ b/worker/storage/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vodplatform.worker</groupId>
+        <artifactId>worker</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>storage</artifactId>
+    <name>vod-worker-storage</name>
+</project>

--- a/worker/storage/src/main/java/com/vodplatform/worker/storage/package-info.java
+++ b/worker/storage/src/main/java/com/vodplatform/worker/storage/package-info.java
@@ -1,0 +1,1 @@
+package com.vodplatform.worker.storage;

--- a/worker/transcode/pom.xml
+++ b/worker/transcode/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vodplatform.worker</groupId>
+        <artifactId>worker</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>transcode</artifactId>
+    <name>vod-worker-transcode</name>
+</project>

--- a/worker/transcode/src/main/java/com/vodplatform/worker/transcode/package-info.java
+++ b/worker/transcode/src/main/java/com/vodplatform/worker/transcode/package-info.java
@@ -1,0 +1,1 @@
+package com.vodplatform.worker.transcode;


### PR DESCRIPTION
This pull request introduces a new multi-module Maven project for the VoD worker, organizes the worker into several submodules, and sets up CI and Docker build infrastructure. The main focus is on establishing the project structure and providing a basic, testable Spring Boot application for the `queue` module. The most important changes are summarized below.

**Project Structure and Maven Modules:**

* Added a new Maven parent project in `worker/pom.xml` that defines six modules: `queue`, `probe`, `transcode`, `storage`, `status`, and `cleanup`. Each module has its own `pom.xml` and package-info file to establish the package structure. [[1]](diffhunk://#diff-2554c796d1dd0a1724899ba63bf0b9bba763705ec8f4f97c3df81106881ee640R1-R33) [[2]](diffhunk://#diff-620998bac563dbb0fa2b7397f77a439afabdbd66e0f4626884821443394c3634R1-R43) [[3]](diffhunk://#diff-4de6b2814483aacad2c217b8b4b584a05ea98a3204d9b5513df0a353286f6f41R1-R15) [[4]](diffhunk://#diff-b98a4e06fcf89a159a83931fbcabb85d7abf775cd91ec80389310ea34d0b0db0R1-R15) [[5]](diffhunk://#diff-2ce6da5ef2a47539f189cc48535379775277ae8feba2b0fc991237a31602aa12R1-R15) [[6]](diffhunk://#diff-5bc9eb8a84b87e5eb0061844f7bdb0cbd9e3b7b3abb6b1e18159aadaff776b45R1-R15) [[7]](diffhunk://#diff-b9d53082898f5f55a59eeccbeb758b59417e5144d768fed895d2b6bd3927a3e7R1-R15) [[8]](diffhunk://#diff-01c6c109b94d1da74f1d7c3dcd598cc537b1fca531dbc6bbb4334eec93ba2f67R1) [[9]](diffhunk://#diff-8d99b7f63809e4568f5bc53859417a12cf63308f7e77207e42c8b5feaa1d28d3R1) [[10]](diffhunk://#diff-36f0b2494a72033b27156159168cd60a985e947e2656548d4dd86c436356e12eR1) [[11]](diffhunk://#diff-bf2a2b87f84b586b83458e63e58bcbfaf62e5451f17e34332424ff34cce22193R1) [[12]](diffhunk://#diff-63a0dd5b4c55a90ed2f1415c3f2e2febb1f0b56abab2ea3122560351771b3b07R1)

**Queue Module Implementation:**

* Implemented a minimal Spring Boot application in `queue` with a startup logger, application configuration, and a test to verify the health endpoint. This serves as a skeleton for further queue consumer and transcoding logic. [[1]](diffhunk://#diff-6e35a8b566a133e2518efce1b20fc3c762a043169e1db2fc52cbaa05abafcc1bR1-R37) [[2]](diffhunk://#diff-011f5be13494e047ac2f5c7565c5cbc6e739e4bb343844d0885381d9c027fcb3R1-R16) [[3]](diffhunk://#diff-09789d7744e5a4440734b8a2643277bcd2370a9fa796172d60f93f0858db1d9eR1-R34)

**Docker and Build Pipeline:**

* Updated `worker/Dockerfile` to use a multi-stage build with Maven, build the `queue` module JAR, and run it as the default container command. Added a healthcheck, exposed port 8081, and set up environment variables. [[1]](diffhunk://#diff-1697ae2c2d6b834df4da0ed07a809b27561dd5689b586236cba7cfb58ebb7657L1-R8) [[2]](diffhunk://#diff-1697ae2c2d6b834df4da0ed07a809b27561dd5689b586236cba7cfb58ebb7657R20-R33)
* Added a new `worker-build` job to the GitHub Actions CI workflow to build and test all worker modules using Maven.

These changes lay the groundwork for a modular, testable worker service and enable automated builds and containerization.