### PR TITLE
feat(database): add Flyway V1 schema migration, closes #4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,47 @@ jobs:
       - name: Build frontend
         working-directory: frontend
         run: npm run build
+  schema-migration:
+    name: Flyway schema migration
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: vod
+          POSTGRES_USER: vod
+          POSTGRES_PASSWORD: vod
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U vod -d vod"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Apply Flyway migration
+        run: >-
+          docker run --rm --network host
+          -v "${{ github.workspace }}/backend/common/src/main/resources/db/migration:/flyway/sql:ro"
+          flyway/flyway:12.10.0
+          -url=jdbc:postgresql://localhost:5432/vod
+          -user=vod
+          -password=vod
+          -connectRetries=60
+          migrate
+
+      - name: Verify ERD schema counts
+        run: |
+          query() {
+            docker run --rm --network host -e PGPASSWORD=vod postgres:16-alpine psql -h localhost -U vod -d vod -Atc "$1"
+          }
+          test "$(query "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE' AND table_name <> 'flyway_schema_history';")" = "15"
+          test "$(query "SELECT count(*) FROM pg_indexes WHERE schemaname = 'public' AND indexname ~ '^(ux|ix)_';")" = "30"
+          test "$(query "SELECT count(*) FROM pg_constraint c JOIN pg_class t ON t.oid = c.conrelid JOIN pg_namespace n ON n.oid = t.relnamespace WHERE n.nspname = 'public' AND t.relname IN ('users', 'roles', 'user_roles', 'refresh_tokens', 'movies', 'genres', 'movie_genres', 'people', 'movie_credits', 'video_assets', 'encoding_jobs', 'playback_progress', 'watchlist_items', 'watch_history', 'ratings');")" = "53"
+          test "$(query "SELECT count(*) FROM pg_constraint c JOIN pg_class t ON t.oid = c.conrelid JOIN pg_namespace n ON n.oid = t.relnamespace WHERE n.nspname = 'public' AND c.contype = 'f' AND t.relname IN ('users', 'roles', 'user_roles', 'refresh_tokens', 'movies', 'genres', 'movie_genres', 'people', 'movie_credits', 'video_assets', 'encoding_jobs', 'playback_progress', 'watchlist_items', 'watch_history', 'ratings');")" = "17"
+          test "$(query "SELECT count(*) FROM pg_constraint c JOIN pg_class t ON t.oid = c.conrelid JOIN pg_namespace n ON n.oid = t.relnamespace WHERE n.nspname = 'public' AND c.contype = 'c' AND t.relname IN ('users', 'roles', 'user_roles', 'refresh_tokens', 'movies', 'genres', 'movie_genres', 'people', 'movie_credits', 'video_assets', 'encoding_jobs', 'playback_progress', 'watchlist_items', 'watch_history', 'ratings');")" = "9"

--- a/backend/common/src/main/resources/db/migration/V1__init_schema.sql
+++ b/backend/common/src/main/resources/db/migration/V1__init_schema.sql
@@ -1,0 +1,166 @@
+CREATE TABLE users (
+    id uuid PRIMARY KEY,
+    email varchar(320) NOT NULL,
+    password_hash varchar(255) NOT NULL,
+    display_name varchar(100) NOT NULL,
+    status varchar(20) NOT NULL CHECK (status IN ('ACTIVE', 'DISABLED')),
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT ux_users_email UNIQUE (email)
+);
+
+CREATE TABLE roles (
+    id smallserial PRIMARY KEY,
+    name varchar(50) NOT NULL,
+    CONSTRAINT ux_roles_name UNIQUE (name)
+);
+
+CREATE TABLE user_roles (
+    user_id uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    role_id smallint NOT NULL REFERENCES roles (id) ON DELETE RESTRICT,
+    PRIMARY KEY (user_id, role_id)
+);
+
+CREATE TABLE refresh_tokens (
+    id uuid PRIMARY KEY,
+    user_id uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    token_hash varchar(255) NOT NULL,
+    expires_at timestamptz NOT NULL,
+    revoked_at timestamptz,
+    created_at timestamptz NOT NULL,
+    CONSTRAINT ux_refresh_tokens_token_hash UNIQUE (token_hash)
+);
+
+CREATE TABLE movies (
+    id uuid PRIMARY KEY,
+    title varchar(255) NOT NULL,
+    slug varchar(255) NOT NULL,
+    description text NOT NULL,
+    release_year int,
+    maturity_rating varchar(20),
+    poster_object_key varchar(512),
+    status varchar(20) NOT NULL CHECK (status IN ('DRAFT', 'PUBLISHED', 'ARCHIVED')),
+    search_vector tsvector,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT ux_movies_slug UNIQUE (slug)
+);
+
+CREATE TABLE genres (
+    id uuid PRIMARY KEY,
+    name varchar(100) NOT NULL,
+    slug varchar(120) NOT NULL,
+    CONSTRAINT ux_genres_name UNIQUE (name),
+    CONSTRAINT ux_genres_slug UNIQUE (slug)
+);
+
+CREATE TABLE movie_genres (
+    movie_id uuid NOT NULL REFERENCES movies (id) ON DELETE CASCADE,
+    genre_id uuid NOT NULL REFERENCES genres (id) ON DELETE RESTRICT,
+    PRIMARY KEY (movie_id, genre_id)
+);
+
+CREATE TABLE people (
+    id uuid PRIMARY KEY,
+    name varchar(255) NOT NULL,
+    slug varchar(255) NOT NULL,
+    CONSTRAINT ux_people_slug UNIQUE (slug)
+);
+
+CREATE TABLE movie_credits (
+    movie_id uuid NOT NULL REFERENCES movies (id) ON DELETE CASCADE,
+    person_id uuid NOT NULL REFERENCES people (id) ON DELETE RESTRICT,
+    credit_role varchar(20) NOT NULL CHECK (credit_role IN ('ACTOR', 'DIRECTOR')),
+    sort_order int,
+    PRIMARY KEY (movie_id, person_id, credit_role)
+);
+
+CREATE TABLE video_assets (
+    id uuid PRIMARY KEY,
+    movie_id uuid NOT NULL REFERENCES movies (id) ON DELETE CASCADE,
+    raw_bucket varchar(100) NOT NULL,
+    raw_object_key varchar(512) NOT NULL,
+    hls_bucket varchar(100),
+    hls_master_object_key varchar(512),
+    status varchar(20) NOT NULL CHECK (status IN ('UPLOADED', 'QUEUED', 'PROCESSING', 'READY', 'FAILED')),
+    duration_seconds int,
+    width int,
+    height int,
+    codec varchar(100),
+    bitrate int,
+    failure_reason text,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT ux_video_assets_raw_object UNIQUE (raw_bucket, raw_object_key)
+);
+
+CREATE TABLE encoding_jobs (
+    id uuid PRIMARY KEY,
+    video_asset_id uuid NOT NULL REFERENCES video_assets (id) ON DELETE CASCADE,
+    status varchar(20) NOT NULL CHECK (status IN ('QUEUED', 'PROCESSING', 'READY', 'FAILED')),
+    attempt int NOT NULL CHECK (attempt >= 1),
+    error_message text,
+    queued_at timestamptz NOT NULL,
+    started_at timestamptz,
+    finished_at timestamptz,
+    CONSTRAINT ux_encoding_jobs_asset_attempt UNIQUE (video_asset_id, attempt)
+);
+
+CREATE TABLE playback_progress (
+    user_id uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    movie_id uuid NOT NULL REFERENCES movies (id) ON DELETE CASCADE,
+    current_seconds int NOT NULL CHECK (current_seconds >= 0),
+    duration_seconds int CHECK (duration_seconds >= 0),
+    finished boolean NOT NULL DEFAULT false,
+    last_played_at timestamptz NOT NULL,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    PRIMARY KEY (user_id, movie_id)
+);
+
+CREATE TABLE watchlist_items (
+    id uuid PRIMARY KEY,
+    user_id uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    movie_id uuid NOT NULL REFERENCES movies (id) ON DELETE CASCADE,
+    created_at timestamptz NOT NULL,
+    CONSTRAINT ux_watchlist_items_user_movie UNIQUE (user_id, movie_id)
+);
+
+CREATE TABLE watch_history (
+    id uuid PRIMARY KEY,
+    user_id uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    movie_id uuid NOT NULL REFERENCES movies (id) ON DELETE CASCADE,
+    started_at timestamptz NOT NULL,
+    last_watched_at timestamptz NOT NULL,
+    completed_at timestamptz,
+    CONSTRAINT ux_watch_history_user_movie UNIQUE (user_id, movie_id)
+);
+
+CREATE TABLE ratings (
+    id uuid PRIMARY KEY,
+    user_id uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    movie_id uuid NOT NULL REFERENCES movies (id) ON DELETE CASCADE,
+    rating int NOT NULL CHECK (rating >= 1 AND rating <= 5),
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT ux_ratings_user_movie UNIQUE (user_id, movie_id)
+);
+
+CREATE INDEX ix_users_status ON users (status);
+CREATE INDEX ix_refresh_tokens_user_id ON refresh_tokens (user_id);
+CREATE INDEX ix_refresh_tokens_expires_at ON refresh_tokens (expires_at);
+CREATE INDEX ix_movies_search_vector ON movies USING GIN (search_vector);
+CREATE INDEX ix_movies_status ON movies (status);
+CREATE INDEX ix_movies_release_year ON movies (release_year);
+CREATE INDEX ix_people_name ON people (name);
+CREATE INDEX ix_movie_credits_person_id ON movie_credits (person_id);
+CREATE INDEX ix_movie_credits_role ON movie_credits (credit_role);
+CREATE INDEX ix_video_assets_movie_id ON video_assets (movie_id);
+CREATE INDEX ix_video_assets_status ON video_assets (status);
+CREATE UNIQUE INDEX ux_video_assets_hls_master ON video_assets (hls_bucket, hls_master_object_key) WHERE hls_master_object_key IS NOT NULL;
+CREATE INDEX ix_encoding_jobs_video_asset_id ON encoding_jobs (video_asset_id);
+CREATE INDEX ix_encoding_jobs_status ON encoding_jobs (status);
+CREATE INDEX ix_playback_progress_user_last_played ON playback_progress (user_id, last_played_at);
+CREATE INDEX ix_watchlist_items_user_created ON watchlist_items (user_id, created_at);
+CREATE INDEX ix_watch_history_user_last_watched ON watch_history (user_id, last_watched_at);
+CREATE INDEX ix_ratings_movie_id ON ratings (movie_id);


### PR DESCRIPTION
## Summary

- Add the baseline Flyway migration `V1__init_schema.sql`.
- Create all 15 tables defined by the frozen ERD.
- Add ERD indexes, unique constraints, foreign keys, and check constraints.
- Enforce the exact status value lists from `docs/architecture/ERD.md`.
- Add a CI schema-migration job using `postgres:16-alpine` and Flyway.
- Verify expected schema counts in CI:
  - 15 application tables
  - 30 ERD indexes
  - 53 constraints
  - 17 foreign keys
  - 9 check constraints

## Scope

This PR completes Sprint 1, Issue 1.4 only.

No seed data is included. Issue 1.5 and later work are not included.

## Verification

- `mvn -f backend/pom.xml -B -ntp verify` passed.
- YAML parser validation passed.
- Migration contains no seed-data statements.
- Static ERD verification passed.
- Docker/Flyway integration will run in GitHub Actions through the `schema-migration` job.

## Review Checklist

- [x] Migration path follows Flyway convention.
- [x] Schema matches the frozen ERD.
- [x] No architecture documentation was modified.
- [x] No seed data was added.
- [x] CI preserves `worker-build`, `frontend-build`, and `schema-migration`.