### PR TITLE
[Feature] Add Docker Compose local stack

### DIFF
--- a/backend/common/src/main/java/com/vodplatform/common/health/HealthController.java
+++ b/backend/common/src/main/java/com/vodplatform/common/health/HealthController.java
@@ -1,0 +1,15 @@
+package com.vodplatform.common.health;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/health")
+public class HealthController {
+
+    @GetMapping
+    public HealthResponse health() {
+        return new HealthResponse("UP");
+    }
+}

--- a/backend/common/src/main/java/com/vodplatform/common/health/HealthResponse.java
+++ b/backend/common/src/main/java/com/vodplatform/common/health/HealthResponse.java
@@ -1,0 +1,4 @@
+package com.vodplatform.common.health;
+
+public record HealthResponse(String status) {
+}

--- a/backend/common/src/test/java/com/vodplatform/common/VodBackendApplicationTests.java
+++ b/backend/common/src/test/java/com/vodplatform/common/VodBackendApplicationTests.java
@@ -2,6 +2,7 @@ package com.vodplatform.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.vodplatform.common.health.HealthResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,5 +31,16 @@ class VodBackendApplicationTests {
         );
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void publicHealthReturnsExpectedPayload() {
+        ResponseEntity<HealthResponse> response = restTemplate.getForEntity(
+                "http://localhost:%d/api/v1/health".formatted(port),
+                HealthResponse.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(new HealthResponse("UP"));
     }
 }

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 10s
     networks:
       - vod_internal
 
@@ -25,6 +26,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 5s
     networks:
       - vod_internal
 
@@ -40,6 +42,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 20s
     networks:
       - vod_internal
 
@@ -51,13 +54,37 @@ services:
       MINIO_ROOT_PASSWORD: ${MINIO_SECRET_KEY:-change-me}
     volumes:
       - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - vod_internal
+
+  flyway:
+    image: flyway/flyway:12.10.0
+    command:
+      - -url=jdbc:postgresql://${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-vod_platform}
+      - -user=${POSTGRES_USER:-vod_app}
+      - -password=${POSTGRES_PASSWORD:-change-me}
+      - -connectRetries=60
+      - -locations=filesystem:/flyway/sql
+      - migrate
+    volumes:
+      - ../backend/common/src/main/resources/db/migration:/flyway/sql:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
     networks:
       - vod_internal
 
   minio-init:
     image: minio/mc:latest
     depends_on:
-      - minio
+      minio:
+        condition: service_healthy
     entrypoint: >
       /bin/sh -c "
       until mc alias set local http://minio:9000 ${MINIO_ACCESS_KEY:-vod_minio} ${MINIO_SECRET_KEY:-change-me}; do sleep 2; done;
@@ -76,18 +103,37 @@ services:
       context: ../backend
       dockerfile: Dockerfile
     environment:
+      APP_ENV: ${APP_ENV:-local}
+      APP_BASE_URL: ${APP_BASE_URL:-http://localhost}
       SERVER_PORT: ${SERVER_PORT:-8080}
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-local}
       SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL:-jdbc:postgresql://postgres:5432/vod_platform}
       SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME:-vod_app}
       SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD:-change-me}
+      JWT_SECRET: ${JWT_SECRET:-change-me-use-a-long-random-secret}
+      JWT_ACCESS_TOKEN_TTL_MINUTES: ${JWT_ACCESS_TOKEN_TTL_MINUTES:-60}
+      JWT_REFRESH_TOKEN_TTL_DAYS: ${JWT_REFRESH_TOKEN_TTL_DAYS:-7}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:5173}
       REDIS_HOST: ${REDIS_HOST:-redis}
+      REDIS_PORT: ${REDIS_PORT:-6379}
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
       RABBITMQ_HOST: ${RABBITMQ_HOST:-rabbitmq}
+      RABBITMQ_PORT: ${RABBITMQ_PORT:-5672}
+      RABBITMQ_USERNAME: ${RABBITMQ_USERNAME:-vod_app}
+      RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD:-change-me}
+      RABBITMQ_ENCODING_QUEUE: ${RABBITMQ_ENCODING_QUEUE:-video-encoding-queue}
       MINIO_ENDPOINT: ${MINIO_ENDPOINT:-http://minio:9000}
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-vod_minio}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-change-me}
       MINIO_BUCKET_RAW: ${MINIO_BUCKET_RAW:-vod-raw}
       MINIO_BUCKET_HLS: ${MINIO_BUCKET_HLS:-vod-hls}
       MINIO_BUCKET_THUMBNAILS: ${MINIO_BUCKET_THUMBNAILS:-vod-thumbnails}
+      MAX_UPLOAD_SIZE_MB: ${MAX_UPLOAD_SIZE_MB:-2048}
+      ALLOWED_VIDEO_MIME_TYPES: ${ALLOWED_VIDEO_MIME_TYPES:-video/mp4,video/x-matroska,video/webm,video/quicktime}
+      TEMP_UPLOAD_DIR: ${TEMP_UPLOAD_DIR:-/tmp/vod-uploads}
     depends_on:
+      flyway:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       redis:
@@ -95,7 +141,9 @@ services:
       rabbitmq:
         condition: service_healthy
       minio:
-        condition: service_started
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
     networks:
       - vod_internal
 
@@ -104,20 +152,38 @@ services:
       context: ../worker
       dockerfile: Dockerfile
     environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-local}
       WORKER_CONCURRENCY: ${WORKER_CONCURRENCY:-1}
       FFMPEG_PATH: ${FFMPEG_PATH:-ffmpeg}
       FFPROBE_PATH: ${FFPROBE_PATH:-ffprobe}
       WORKER_TEMP_DIR: ${WORKER_TEMP_DIR:-/tmp/vod-worker}
+      HLS_SEGMENT_SECONDS: ${HLS_SEGMENT_SECONDS:-6}
+      HLS_TARGET_HEIGHT: ${HLS_TARGET_HEIGHT:-720}
       SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL:-jdbc:postgresql://postgres:5432/vod_platform}
+      SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME:-vod_app}
+      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD:-change-me}
       RABBITMQ_HOST: ${RABBITMQ_HOST:-rabbitmq}
+      RABBITMQ_PORT: ${RABBITMQ_PORT:-5672}
+      RABBITMQ_USERNAME: ${RABBITMQ_USERNAME:-vod_app}
+      RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD:-change-me}
+      RABBITMQ_ENCODING_QUEUE: ${RABBITMQ_ENCODING_QUEUE:-video-encoding-queue}
       MINIO_ENDPOINT: ${MINIO_ENDPOINT:-http://minio:9000}
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-vod_minio}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-change-me}
+      MINIO_BUCKET_RAW: ${MINIO_BUCKET_RAW:-vod-raw}
+      MINIO_BUCKET_HLS: ${MINIO_BUCKET_HLS:-vod-hls}
+      MINIO_BUCKET_THUMBNAILS: ${MINIO_BUCKET_THUMBNAILS:-vod-thumbnails}
     depends_on:
+      flyway:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
       minio:
-        condition: service_started
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
     networks:
       - vod_internal
 
@@ -125,18 +191,32 @@ services:
     build:
       context: ../frontend
       dockerfile: Dockerfile
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
     networks:
       - vod_internal
 
   nginx:
     image: nginx:1.27-alpine
     depends_on:
-      - frontend
-      - backend
+      frontend:
+        condition: service_healthy
+      backend:
+        condition: service_healthy
     ports:
       - "${NGINX_HTTP_PORT:-80}:80"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
     networks:
       - vod_internal
 

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -10,11 +10,6 @@ http {
     server_tokens off;
     client_max_body_size 2048m;
 
-    types {
-        application/vnd.apple.mpegurl m3u8;
-        video/mp2t ts;
-    }
-
     upstream frontend_upstream {
         server frontend:80;
     }


### PR DESCRIPTION
## What changed

- Complete the local Docker Compose baseline for PostgreSQL, Redis, RabbitMQ, MinIO, Flyway, backend, worker, frontend, and Nginx.
- Add dependency health conditions and one-shot initialization for Flyway and the private MinIO buckets.
- Add the public `GET /api/v1/health` response and integration coverage.
- Align Nginx health probing and MIME configuration with the frozen architecture.

## Why

This completes Sprint 1 Issue 1.5 and provides a reproducible local stack before production Compose work begins.

## Verification

- Backend: 12/12 modules successful; 2 tests passed.
- Worker: 7/7 modules successful; 1 test passed.
- Frontend production build successful.
- `docker compose config --quiet` passed with Docker Engine 29.6.2 and Compose v5.3.1.
- Runtime smoke: PostgreSQL, Redis, RabbitMQ, MinIO, backend, worker, frontend, and Nginx healthy.
- `/`, `/api/v1/health`, and `/actuator/health` returned HTTP 200.
- Flyway V1 succeeded; 15 application tables and 30 application indexes verified.
- `vod-raw`, `vod-hls`, and `vod-thumbnails` exist and remain private.

## Self-review checklist

- [x] The code is buildable and runnable.
- [x] Build and IDE artifacts are excluded.
- [x] The commit history is clean and meaningful.

Closes #5