### PR TITLE
[Feature] Complete production Compose baseline

### DIFF
--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -9,6 +9,8 @@ services:
 
   redis:
     restart: unless-stopped
+    volumes:
+      - redis_data:/data
     deploy:
       resources:
         limits:
@@ -55,8 +57,24 @@ services:
           cpus: "0.25"
           memory: 128M
 
+  flyway:
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 256M
+
+  minio-init:
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 128M
+
   nginx:
     restart: unless-stopped
+    ports:
+      - "${NGINX_HTTPS_PORT:-443}:443"
     deploy:
       resources:
         limits:
@@ -65,5 +83,6 @@ services:
 
 volumes:
   postgres_data:
+  redis_data:
   rabbitmq_data:
   minio_data:

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -64,4 +64,15 @@ http {
             proxy_set_header X-Request-ID $request_id;
         }
     }
+
+    # Phase 5 HTTPS placeholder. Certificate provisioning and renewal with
+    # Let's Encrypt are intentionally deferred until a public domain is ready.
+    # server {
+    #     listen 443 ssl;
+    #     listen [::]:443 ssl;
+    #     server_name <PUBLIC_DOMAIN>;
+    #
+    #     ssl_certificate /etc/letsencrypt/live/<PUBLIC_DOMAIN>/fullchain.pem;
+    #     ssl_certificate_key /etc/letsencrypt/live/<PUBLIC_DOMAIN>/privkey.pem;
+    # }
 }


### PR DESCRIPTION
## What changed

- Added a persistent Redis named volume mounted at `/data`.
- Added CPU and memory limits for the Flyway and MinIO initialization jobs so every Compose service has explicit limits.
- Exposed the configurable production HTTPS port and documented the deferred Nginx/Let's Encrypt certificate paths.

## Why

This completes the Issue 1.6 production Compose baseline and aligns the deployment overlay with the VPS resource constraints in NFR-002. TLS certificate provisioning remains intentionally deferred until the Phase 5 public-domain deployment.

## Verification

- `docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.prod.yml config --quiet`
- Rendered-config assertions: 10 services, limits on every service, restart policy on all long-lived services, required persistent volumes, and Nginx targets 80/443
- `nginx -t` using `nginx:1.27-alpine`

## Self-review checklist

- [x] Is the code buildable and runnable?
- [x] Are build/IDE files (like `target/`, `.idea/`, and `*.iml`) excluded?
- [x] Is the commit history clean and meaningful?

Closes #6