### PR TITLE
[Docs] Complete Sprint 1 definition of done

### DIFF
--- a/docs/requirements/BACKLOG.md
+++ b/docs/requirements/BACKLOG.md
@@ -141,14 +141,14 @@ Create `docker-compose.prod.yml` with resource limits, restart policies, named v
 
 ### Sprint 1 Definition of Done
 
-- [ ] Backend, worker, and frontend build and start successfully
-- [ ] Flyway migration creates all ERD tables in PostgreSQL
-- [ ] Docker Compose local stack starts all services with health checks passing
-- [ ] Nginx routes frontend, backend health endpoint, and placeholder API paths
-- [ ] `.env.example` is complete with placeholders
-- [ ] Production Compose includes resource limits and named volumes
-- [ ] README documents how to run the local stack
-- [ ] No secrets are committed
+- [x] Backend, worker, and frontend build and start successfully
+- [x] Flyway migration creates all ERD tables in PostgreSQL
+- [x] Docker Compose local stack starts all services with health checks passing
+- [x] Nginx routes frontend, backend health endpoint, and placeholder API paths
+- [x] `.env.example` is complete with placeholders
+- [x] Production Compose includes resource limits and named volumes
+- [x] README documents how to run the local stack
+- [x] No secrets are committed
 
 ---
 


### PR DESCRIPTION
## What changed

- Marked all eight Sprint 1 Definition of Done items complete in `docs/requirements/BACKLOG.md`.
- Kept this batch documentation-only; no implementation, infrastructure, or Sprint 2 content changed.

## Why

All Sprint 1 issues are closed and every checklist item was independently re-verified on merged `main` before updating the source-of-truth backlog.

## Verification evidence

- Backend, worker, and frontend: fresh Compose build/start succeeded; `main` CI build/test jobs passed.
- Flyway: V1 succeeded and PostgreSQL contained all 15 ERD tables plus `flyway_schema_history`.
- Local Compose: all 8 long-lived services reported healthy; Flyway and MinIO init exited 0.
- Nginx: frontend returned 200, `/api/v1/health` returned 200/UP, and a placeholder API path reached Spring and returned its expected 404 response.
- Environment: all 40 variables referenced by local Compose are present in `.env.example`.
- Production Compose: every service has CPU/memory limits; all long-lived services use `unless-stopped`; named data volumes include PostgreSQL, RabbitMQ, Redis, and MinIO; Nginx publishes 80/443.
- README: local stack build/start/status/log/down workflow is documented.
- Secret hygiene: only `.env.example` is tracked; common cloud token/private-key signatures were not found.
- GitHub Issues #1 through #6 are closed and the merged `main` CI run passed all 5 jobs.

## Self-review checklist

- [x] Is the code buildable and runnable?
- [x] Are build/IDE files (like `target/`, `.idea/`, `*.iml`) excluded?
- [x] Is the commit history clean and meaningful?
- [x] Is the change limited to the Sprint 1 DoD checklist?