### PR TITLE
[Docs] Align registration contract with Sprint scope

### DIFF
--- a/docs/architecture/API-CONTRACT.yaml
+++ b/docs/architecture/API-CONTRACT.yaml
@@ -63,7 +63,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AuthResponse"
+                $ref: "#/components/schemas/UserProfile"
         "400":
           $ref: "#/components/responses/ValidationError"
         "409":

--- a/docs/requirements/BACKLOG.md
+++ b/docs/requirements/BACKLOG.md
@@ -162,14 +162,16 @@ Create `docker-compose.prod.yml` with resource limits, restart policies, named v
 ### Issue 2.1: Backend Auth Service - Registration
 
 **Description:**  
-Implement user registration endpoint `POST /api/v1/auth/register` with email, password, display_name. Hash passwords with BCrypt. Assign `ROLE_USER` by default. Return DTO without password.
+Implement user registration endpoint `POST /api/v1/auth/register` with request fields `email`, `password`, and `displayName`. Map `displayName` to `users.display_name`. Hash passwords with BCrypt, create the user with `ACTIVE` status, and assign `ROLE_USER` by default. Return `201 Created` with the existing `UserProfile` DTO. Registration does not issue access or refresh tokens; token issuance remains scoped to Issue 2.2.
 
 **Acceptance Criteria:**
 - Registration validates email format, password strength, and display name length
 - Duplicate email returns 409 Conflict
 - Password is stored as BCrypt hash
+- New user has `ACTIVE` status
 - New user has `ROLE_USER` in `user_roles` table
-- Response DTO excludes password hash
+- Successful registration returns 201 Created with the existing `UserProfile` DTO
+- Response DTO excludes password hash, access token, and refresh token
 - Unit tests cover validation and service logic
 
 **Dependencies:** Sprint 1 complete


### PR DESCRIPTION
## What changed

- Changed `POST /api/v1/auth/register` success schema from `AuthResponse` to the existing `UserProfile`.
- Aligned Sprint 2 Issue 2.1 wording with the JSON field `displayName` and its mapping to `users.display_name`.
- Clarified that registration creates an `ACTIVE` user, assigns `ROLE_USER`, returns `201 Created`, and does not issue access or refresh tokens.
- Kept JWT and refresh-token issuance scoped to Issue 2.2.

## Why

The frozen backlog and OpenAPI contract disagreed: the registration path reused `AuthResponse`, which requires access and refresh tokens, while token issuance belongs to Issue 2.2. The backlog also leaked the database-style `display_name` identifier into the JSON request wording.

## Impact

This is a documentation-only source-of-truth correction. It does not implement or close #17, modify application code, or update the GitHub issue body.

## Verification

- Confirmed registration still uses `RegisterRequest`.
- Confirmed required request fields are `email`, `password`, and `displayName`.
- Confirmed `201` now uses `UserProfile`; `400` validation and `409` conflict responses remain unchanged.
- Confirmed the registration path no longer references `AuthResponse`.
- Confirmed the Issue 2.1 backlog text matches the corrected API contract and preserves Issue 2.2 token scope.
- Ran `git diff --check`.
- Confirmed only `docs/architecture/API-CONTRACT.yaml` and `docs/requirements/BACKLOG.md` changed.

## Self-review checklist

- [x] Is the code buildable and runnable? (Documentation-only change; no runtime code changed.)
- [x] Are build/IDE files (like `target/`, `.idea/`, `*.iml`) excluded?
- [x] Is the commit history clean and meaningful?
- [x] Does this PR avoid closing #17 before implementation?