### PR TITLE
[Docs] Update current project step

### DIFF
--- a/docs/requirements/PROJECTPLAN.md
+++ b/docs/requirements/PROJECTPLAN.md
@@ -87,11 +87,10 @@ See `BACKLOG.md` for detailed sprint backlog with issues, acceptance criteria, d
 
 ## Current Next Step
 
-Continue Phase 0 / Batch 4 by creating the baseline container and deployment skeleton only:
+Phase 3 - Feature Development is active.
 
-- backend, worker, and frontend Dockerfiles
-- local and production Docker Compose skeletons
-- Nginx routing skeleton for frontend, API, and HLS paths
-- CI skeleton that validates builds and configuration as far as possible
+- Sprint 1 - Foundation is complete.
+- Sprint 2 - Auth is active.
+- The next implementation batch is Issue 2.1 / GitHub Issue #17 - Backend Auth Service - Registration.
 
-Do not add business logic in this batch. Phase 2 architecture is already frozen for MVP implementation.
+GitHub Issue #17 remains `OPEN`; implementation has not started.

--- a/docs/requirements/PROJECTPLAN.md
+++ b/docs/requirements/PROJECTPLAN.md
@@ -92,5 +92,3 @@ Phase 3 - Feature Development is active.
 - Sprint 1 - Foundation is complete.
 - Sprint 2 - Auth is active.
 - The next implementation batch is Issue 2.1 / GitHub Issue #17 - Backend Auth Service - Registration.
-
-GitHub Issue #17 remains `OPEN`; implementation has not started.


### PR DESCRIPTION
## What changed

- Updated only the `Current Next Step` section in `docs/requirements/PROJECTPLAN.md`.
- Recorded Phase 3 as active, Sprint 1 as complete, and Sprint 2 Auth as active.
- Identified Issue 2.1 / GitHub Issue #17 as the next isolated implementation batch.

## Why

The section still pointed to Phase 0 / Batch 4 even though the foundation sprint and its planning gates are complete.

## Impact

Project navigation now reflects the current delivery state. No sprint definitions, architecture documents, backlog content, or implementation code changed.

## Verification

- Confirmed only `docs/requirements/PROJECTPLAN.md` changed.
- Confirmed the updated section contains all four approved state statements.
- Ran `git diff --check`.
- Confirmed Issue #17 remains `OPEN`.

## Self-review checklist

- [x] Is the code buildable and runnable? (Documentation-only change; no runtime code changed.)
- [x] Are build/IDE files (like `target/`, `.idea/`, `*.iml`) excluded?
- [x] Is the commit history clean and meaningful?
- [x] Is the change limited to the stale planning section?