### PR TITLE
[Feature] Implement backend user registration

### DIFF
--- a/backend/auth/pom.xml
+++ b/backend/auth/pom.xml
@@ -12,4 +12,33 @@
 
     <artifactId>auth</artifactId>
     <name>vod-backend-auth</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/backend/auth/src/main/java/com/vodplatform/auth/config/AuthConfiguration.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/config/AuthConfiguration.java
@@ -1,0 +1,23 @@
+package com.vodplatform.auth.config;
+
+import com.vodplatform.auth.persistence.RoleEntity;
+import com.vodplatform.auth.persistence.RoleRepository;
+import com.vodplatform.auth.persistence.UserEntity;
+import com.vodplatform.auth.persistence.UserRepository;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration(proxyBeanMethods = false)
+@EntityScan(basePackageClasses = {UserEntity.class, RoleEntity.class})
+@EnableJpaRepositories(basePackageClasses = {UserRepository.class, RoleRepository.class})
+public class AuthConfiguration {
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/dto/RegisterRequest.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/dto/RegisterRequest.java
@@ -1,0 +1,12 @@
+package com.vodplatform.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RegisterRequest(
+        @NotBlank @Email @Size(max = 320) String email,
+        @NotBlank @Size(min = 8, max = 72) String password,
+        @NotBlank @Size(min = 2, max = 100) String displayName
+) {
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/dto/UserProfile.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/dto/UserProfile.java
@@ -1,0 +1,16 @@
+package com.vodplatform.auth.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record UserProfile(
+        UUID id,
+        String email,
+        String displayName,
+        List<String> roles
+) {
+
+    public UserProfile {
+        roles = List.copyOf(roles);
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/exception/ApiError.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/exception/ApiError.java
@@ -1,0 +1,19 @@
+package com.vodplatform.auth.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.Instant;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ApiError(
+        Instant timestamp,
+        int status,
+        String code,
+        String message,
+        List<ApiFieldError> fieldErrors
+) {
+
+    public ApiError {
+        fieldErrors = fieldErrors == null ? List.of() : List.copyOf(fieldErrors);
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/exception/ApiFieldError.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/exception/ApiFieldError.java
@@ -1,0 +1,4 @@
+package com.vodplatform.auth.exception;
+
+public record ApiFieldError(String field, String message) {
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/exception/EmailAlreadyExistsException.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/exception/EmailAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package com.vodplatform.auth.exception;
+
+public class EmailAlreadyExistsException extends RuntimeException {
+
+    public EmailAlreadyExistsException() {
+        super("Email is already registered");
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/exception/RegistrationExceptionHandler.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/exception/RegistrationExceptionHandler.java
@@ -1,0 +1,66 @@
+package com.vodplatform.auth.exception;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class RegistrationExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException exception) {
+        List<ApiFieldError> fieldErrors = exception.getBindingResult().getFieldErrors().stream()
+                .map(error -> new ApiFieldError(error.getField(), error.getDefaultMessage()))
+                .sorted(Comparator.comparing(ApiFieldError::field))
+                .toList();
+
+        return buildResponse(
+                HttpStatus.BAD_REQUEST,
+                "VALIDATION_ERROR",
+                "Request validation failed",
+                fieldErrors
+        );
+    }
+
+    @ExceptionHandler(EmailAlreadyExistsException.class)
+    ResponseEntity<ApiError> handleDuplicateEmail(EmailAlreadyExistsException exception) {
+        return buildResponse(
+                HttpStatus.CONFLICT,
+                "EMAIL_ALREADY_EXISTS",
+                exception.getMessage(),
+                List.of()
+        );
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    ResponseEntity<ApiError> handleUnreadableRequest() {
+        return buildResponse(
+                HttpStatus.BAD_REQUEST,
+                "MALFORMED_REQUEST",
+                "Request body is missing or malformed",
+                List.of()
+        );
+    }
+
+    private ResponseEntity<ApiError> buildResponse(
+            HttpStatus status,
+            String code,
+            String message,
+            List<ApiFieldError> fieldErrors
+    ) {
+        ApiError error = new ApiError(
+                Instant.now(),
+                status.value(),
+                code,
+                message,
+                fieldErrors
+        );
+        return ResponseEntity.status(status).body(error);
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/persistence/RoleEntity.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/persistence/RoleEntity.java
@@ -1,0 +1,31 @@
+package com.vodplatform.auth.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "roles")
+public class RoleEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Short id;
+
+    @Column(name = "name", nullable = false, unique = true, length = 50)
+    private String name;
+
+    protected RoleEntity() {
+    }
+
+    RoleEntity(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/persistence/RoleRepository.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/persistence/RoleRepository.java
@@ -1,0 +1,9 @@
+package com.vodplatform.auth.persistence;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoleRepository extends JpaRepository<RoleEntity, Short> {
+
+    Optional<RoleEntity> findByName(String name);
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/persistence/UserEntity.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/persistence/UserEntity.java
@@ -1,0 +1,101 @@
+package com.vodplatform.auth.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.UUID;
+
+@Entity
+@Table(name = "users")
+public class UserEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private UUID id;
+
+    @Column(name = "email", nullable = false, unique = true, length = 320)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash;
+
+    @Column(name = "display_name", nullable = false, length = 100)
+    private String displayName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private UserStatus status;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "user_roles",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id")
+    )
+    private Set<RoleEntity> roles = new LinkedHashSet<>();
+
+    protected UserEntity() {
+    }
+
+    public UserEntity(
+            UUID id,
+            String email,
+            String passwordHash,
+            String displayName,
+            UserStatus status,
+            Instant createdAt,
+            Instant updatedAt
+    ) {
+        this.id = id;
+        this.email = email;
+        this.passwordHash = passwordHash;
+        this.displayName = displayName;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public void addRole(RoleEntity role) {
+        roles.add(role);
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public UserStatus getStatus() {
+        return status;
+    }
+
+    public Set<RoleEntity> getRoles() {
+        return Set.copyOf(roles);
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/persistence/UserRepository.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/persistence/UserRepository.java
@@ -1,0 +1,9 @@
+package com.vodplatform.auth.persistence;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<UserEntity, UUID> {
+
+    boolean existsByEmail(String email);
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/persistence/UserStatus.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/persistence/UserStatus.java
@@ -1,0 +1,6 @@
+package com.vodplatform.auth.persistence;
+
+public enum UserStatus {
+    ACTIVE,
+    DISABLED
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/service/RegistrationService.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/service/RegistrationService.java
@@ -1,0 +1,90 @@
+package com.vodplatform.auth.service;
+
+import com.vodplatform.auth.dto.RegisterRequest;
+import com.vodplatform.auth.dto.UserProfile;
+import com.vodplatform.auth.exception.EmailAlreadyExistsException;
+import com.vodplatform.auth.persistence.RoleEntity;
+import com.vodplatform.auth.persistence.RoleRepository;
+import com.vodplatform.auth.persistence.UserEntity;
+import com.vodplatform.auth.persistence.UserRepository;
+import com.vodplatform.auth.persistence.UserStatus;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RegistrationService {
+
+    static final String DEFAULT_ROLE = "ROLE_USER";
+
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public RegistrationService(
+            UserRepository userRepository,
+            RoleRepository roleRepository,
+            PasswordEncoder passwordEncoder
+    ) {
+        this.userRepository = userRepository;
+        this.roleRepository = roleRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Transactional
+    public UserProfile register(RegisterRequest request) {
+        if (userRepository.existsByEmail(request.email())) {
+            throw new EmailAlreadyExistsException();
+        }
+
+        RoleEntity role = roleRepository.findByName(DEFAULT_ROLE)
+                .orElseThrow(() -> new IllegalStateException("Required role is not configured"));
+        Instant now = Instant.now();
+        UserEntity user = new UserEntity(
+                UUID.randomUUID(),
+                request.email(),
+                passwordEncoder.encode(request.password()),
+                request.displayName(),
+                UserStatus.ACTIVE,
+                now,
+                now
+        );
+        user.addRole(role);
+
+        try {
+            UserEntity savedUser = userRepository.saveAndFlush(user);
+            return toProfile(savedUser);
+        } catch (DataIntegrityViolationException exception) {
+            if (hasConstraint(exception, "ux_users_email")) {
+                throw new EmailAlreadyExistsException();
+            }
+            throw exception;
+        }
+    }
+
+    private boolean hasConstraint(Throwable exception, String expectedConstraint) {
+        Throwable current = exception;
+        while (current != null) {
+            if (current instanceof ConstraintViolationException constraintViolation
+                    && expectedConstraint.equalsIgnoreCase(constraintViolation.getConstraintName())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private UserProfile toProfile(UserEntity user) {
+        List<String> roles = user.getRoles().stream()
+                .map(RoleEntity::getName)
+                .sorted(Comparator.naturalOrder())
+                .toList();
+        return new UserProfile(user.getId(), user.getEmail(), user.getDisplayName(), roles);
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/web/RegistrationController.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/web/RegistrationController.java
@@ -1,0 +1,29 @@
+package com.vodplatform.auth.web;
+
+import com.vodplatform.auth.dto.RegisterRequest;
+import com.vodplatform.auth.dto.UserProfile;
+import com.vodplatform.auth.service.RegistrationService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class RegistrationController {
+
+    private final RegistrationService registrationService;
+
+    public RegistrationController(RegistrationService registrationService) {
+        this.registrationService = registrationService;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<UserProfile> register(@Valid @RequestBody RegisterRequest request) {
+        UserProfile profile = registrationService.register(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(profile);
+    }
+}

--- a/backend/auth/src/test/java/com/vodplatform/auth/dto/RegisterRequestValidationTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/dto/RegisterRequestValidationTest.java
@@ -1,0 +1,90 @@
+package com.vodplatform.auth.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class RegisterRequestValidationTest {
+
+    private static jakarta.validation.ValidatorFactory validatorFactory;
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUpValidator() {
+        validatorFactory = Validation.buildDefaultValidatorFactory();
+        validator = validatorFactory.getValidator();
+    }
+
+    @AfterAll
+    static void closeValidator() {
+        validatorFactory.close();
+    }
+
+    @Test
+    void acceptsRequestMatchingFrozenContract() {
+        RegisterRequest request = new RegisterRequest(
+                "viewer@example.com",
+                "strong-password",
+                "Viewer"
+        );
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+
+    @Test
+    void rejectsInvalidEmailWeakPasswordAndShortDisplayName() {
+        RegisterRequest request = new RegisterRequest("invalid", "short", "x");
+
+        Set<ConstraintViolation<RegisterRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString())
+                .contains("email", "password", "displayName");
+    }
+
+    @Test
+    void rejectsFieldsLongerThanContractMaximums() {
+        RegisterRequest request = new RegisterRequest(
+                "a".repeat(309) + "@example.com",
+                "p".repeat(73),
+                "d".repeat(101)
+        );
+
+        Set<ConstraintViolation<RegisterRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString())
+                .contains("email", "password", "displayName");
+    }
+
+    @Test
+    void acceptsExactLengthBoundaries() {
+        String maximumLengthEmail = "a".repeat(64) + "@"
+                + String.join(".", "b".repeat(63), "c".repeat(63), "d".repeat(63), "e".repeat(63));
+        RegisterRequest minimums = new RegisterRequest("a@b.co", "p".repeat(8), "ab");
+        RegisterRequest maximums = new RegisterRequest(
+                maximumLengthEmail,
+                "p".repeat(72),
+                "d".repeat(100)
+        );
+
+        assertThat(maximumLengthEmail).hasSize(320);
+        assertThat(validator.validate(minimums)).isEmpty();
+        assertThat(validator.validate(maximums)).isEmpty();
+    }
+
+    @Test
+    void rejectsMissingRequiredFields() {
+        RegisterRequest request = new RegisterRequest(null, null, null);
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getPropertyPath().toString())
+                .containsExactlyInAnyOrder("email", "password", "displayName");
+    }
+}

--- a/backend/auth/src/test/java/com/vodplatform/auth/persistence/AuthPersistenceTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/persistence/AuthPersistenceTest.java
@@ -1,0 +1,82 @@
+package com.vodplatform.auth.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.vodplatform.auth.config.AuthConfiguration;
+import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ContextConfiguration;
+
+@DataJpaTest
+@ContextConfiguration(classes = AuthConfiguration.class)
+class AuthPersistenceTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    void persistsActiveUserAndRoleAssignmentUsingFrozenSchemaMapping() {
+        RoleEntity role = roleRepository.saveAndFlush(new RoleEntity("ROLE_USER"));
+        Instant now = Instant.now();
+        UserEntity user = new UserEntity(
+                UUID.randomUUID(),
+                "viewer@example.com",
+                "$2a$10$placeholder",
+                "Viewer",
+                UserStatus.ACTIVE,
+                now,
+                now
+        );
+        user.addRole(role);
+
+        userRepository.saveAndFlush(user);
+        entityManager.clear();
+
+        UserEntity persisted = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(persisted.getEmail()).isEqualTo("viewer@example.com");
+        assertThat(persisted.getDisplayName()).isEqualTo("Viewer");
+        assertThat(persisted.getPasswordHash()).isEqualTo("$2a$10$placeholder");
+        assertThat(persisted.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(persisted.getRoles()).extracting(RoleEntity::getName).containsExactly("ROLE_USER");
+        assertThat(userRepository.existsByEmail("viewer@example.com")).isTrue();
+    }
+
+    @Test
+    void databaseRejectsDuplicateEmail() {
+        Instant now = Instant.now();
+        UserEntity firstUser = new UserEntity(
+                UUID.randomUUID(),
+                "duplicate@example.com",
+                "$2a$10$first",
+                "First Viewer",
+                UserStatus.ACTIVE,
+                now,
+                now
+        );
+        UserEntity duplicateUser = new UserEntity(
+                UUID.randomUUID(),
+                "duplicate@example.com",
+                "$2a$10$second",
+                "Second Viewer",
+                UserStatus.ACTIVE,
+                now,
+                now
+        );
+        userRepository.saveAndFlush(firstUser);
+
+        assertThatThrownBy(() -> userRepository.saveAndFlush(duplicateUser))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+}

--- a/backend/auth/src/test/java/com/vodplatform/auth/service/RegistrationServiceTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/service/RegistrationServiceTest.java
@@ -1,0 +1,137 @@
+package com.vodplatform.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.vodplatform.auth.dto.RegisterRequest;
+import com.vodplatform.auth.dto.UserProfile;
+import com.vodplatform.auth.exception.EmailAlreadyExistsException;
+import com.vodplatform.auth.persistence.RoleEntity;
+import com.vodplatform.auth.persistence.RoleRepository;
+import com.vodplatform.auth.persistence.UserEntity;
+import com.vodplatform.auth.persistence.UserRepository;
+import com.vodplatform.auth.persistence.UserStatus;
+import java.util.Optional;
+import java.sql.SQLException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.hibernate.exception.ConstraintViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class RegistrationServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RoleRepository roleRepository;
+
+    @Mock
+    private RoleEntity role;
+
+    private BCryptPasswordEncoder passwordEncoder;
+    private RegistrationService registrationService;
+
+    @BeforeEach
+    void setUp() {
+        passwordEncoder = new BCryptPasswordEncoder();
+        registrationService = new RegistrationService(userRepository, roleRepository, passwordEncoder);
+    }
+
+    @Test
+    void registersActiveUserWithBcryptPasswordAndDefaultRole() {
+        RegisterRequest request = new RegisterRequest(
+                "viewer@example.com",
+                "strong-password",
+                "Viewer"
+        );
+        when(userRepository.existsByEmail(request.email())).thenReturn(false);
+        when(roleRepository.findByName("ROLE_USER")).thenReturn(Optional.of(role));
+        when(role.getName()).thenReturn("ROLE_USER");
+        when(userRepository.saveAndFlush(any(UserEntity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        UserProfile profile = registrationService.register(request);
+
+        ArgumentCaptor<UserEntity> userCaptor = ArgumentCaptor.forClass(UserEntity.class);
+        verify(userRepository).saveAndFlush(userCaptor.capture());
+        UserEntity savedUser = userCaptor.getValue();
+        assertThat(savedUser.getEmail()).isEqualTo(request.email());
+        assertThat(savedUser.getDisplayName()).isEqualTo(request.displayName());
+        assertThat(savedUser.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(savedUser.getRoles()).containsExactly(role);
+        assertThat(savedUser.getPasswordHash()).isNotEqualTo(request.password());
+        assertThat(passwordEncoder.matches(request.password(), savedUser.getPasswordHash())).isTrue();
+        assertThat(profile.id()).isEqualTo(savedUser.getId());
+        assertThat(profile.email()).isEqualTo(request.email());
+        assertThat(profile.displayName()).isEqualTo(request.displayName());
+        assertThat(profile.roles()).containsExactly("ROLE_USER");
+    }
+
+    @Test
+    void rejectsKnownDuplicateEmailBeforeEncodingOrSaving() {
+        RegisterRequest request = new RegisterRequest(
+                "viewer@example.com",
+                "strong-password",
+                "Viewer"
+        );
+        when(userRepository.existsByEmail(request.email())).thenReturn(true);
+
+        assertThatThrownBy(() -> registrationService.register(request))
+                .isInstanceOf(EmailAlreadyExistsException.class);
+
+        verify(roleRepository, never()).findByName(any());
+        verify(userRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void mapsUniqueConstraintRaceToDuplicateEmailConflict() {
+        RegisterRequest request = new RegisterRequest(
+                "viewer@example.com",
+                "strong-password",
+                "Viewer"
+        );
+        when(userRepository.existsByEmail(request.email())).thenReturn(false);
+        when(roleRepository.findByName("ROLE_USER")).thenReturn(Optional.of(role));
+        when(userRepository.saveAndFlush(any(UserEntity.class)))
+                .thenThrow(new DataIntegrityViolationException(
+                        "duplicate email",
+                        new ConstraintViolationException(
+                                "duplicate email",
+                                new SQLException("duplicate email"),
+                                "ux_users_email"
+                        )
+                ));
+
+        assertThatThrownBy(() -> registrationService.register(request))
+                .isInstanceOf(EmailAlreadyExistsException.class);
+    }
+
+    @Test
+    void doesNotMaskUnrelatedPersistenceFailuresAsDuplicateEmail() {
+        RegisterRequest request = new RegisterRequest(
+                "viewer@example.com",
+                "strong-password",
+                "Viewer"
+        );
+        DataIntegrityViolationException persistenceFailure = new DataIntegrityViolationException(
+                "unrelated constraint"
+        );
+        when(userRepository.existsByEmail(request.email())).thenReturn(false);
+        when(roleRepository.findByName("ROLE_USER")).thenReturn(Optional.of(role));
+        when(userRepository.saveAndFlush(any(UserEntity.class))).thenThrow(persistenceFailure);
+
+        assertThatThrownBy(() -> registrationService.register(request))
+                .isSameAs(persistenceFailure);
+    }
+}

--- a/backend/auth/src/test/java/com/vodplatform/auth/web/RegistrationControllerTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/web/RegistrationControllerTest.java
@@ -1,0 +1,131 @@
+package com.vodplatform.auth.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.vodplatform.auth.dto.RegisterRequest;
+import com.vodplatform.auth.dto.UserProfile;
+import com.vodplatform.auth.exception.EmailAlreadyExistsException;
+import com.vodplatform.auth.exception.RegistrationExceptionHandler;
+import com.vodplatform.auth.service.RegistrationService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+@ExtendWith(MockitoExtension.class)
+class RegistrationControllerTest {
+
+    @Mock
+    private RegistrationService registrationService;
+
+    private LocalValidatorFactoryBean validator;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new RegistrationController(registrationService))
+                .setControllerAdvice(new RegistrationExceptionHandler())
+                .setValidator(validator)
+                .build();
+    }
+
+    @AfterEach
+    void closeValidatorFactory() {
+        validator.close();
+    }
+
+    @Test
+    void returnsCreatedUserProfileWithoutSensitiveFields() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UserProfile profile = new UserProfile(
+                userId,
+                "viewer@example.com",
+                "Viewer",
+                List.of("ROLE_USER")
+        );
+        when(registrationService.register(any(RegisterRequest.class))).thenReturn(profile);
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "viewer@example.com",
+                                  "password": "strong-password",
+                                  "displayName": "Viewer"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(userId.toString()))
+                .andExpect(jsonPath("$.email").value("viewer@example.com"))
+                .andExpect(jsonPath("$.displayName").value("Viewer"))
+                .andExpect(jsonPath("$.roles[0]").value("ROLE_USER"))
+                .andExpect(jsonPath("$.password").doesNotExist())
+                .andExpect(jsonPath("$.passwordHash").doesNotExist())
+                .andExpect(jsonPath("$.accessToken").doesNotExist())
+                .andExpect(jsonPath("$.refreshToken").doesNotExist());
+    }
+
+    @Test
+    void returnsBadRequestWithFieldErrorsForInvalidRequest() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "invalid",
+                                  "password": "short",
+                                  "displayName": "x"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.fieldErrors").isArray());
+    }
+
+    @Test
+    void returnsConflictForDuplicateEmail() throws Exception {
+        when(registrationService.register(any(RegisterRequest.class)))
+                .thenThrow(new EmailAlreadyExistsException());
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "viewer@example.com",
+                                  "password": "strong-password",
+                                  "displayName": "Viewer"
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.code").value("EMAIL_ALREADY_EXISTS"))
+                .andExpect(jsonPath("$.message").value("Email is already registered"));
+    }
+
+    @Test
+    void returnsApiErrorForMalformedJson() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("MALFORMED_REQUEST"))
+                .andExpect(jsonPath("$.message").value("Request body is missing or malformed"));
+    }
+}

--- a/backend/common/pom.xml
+++ b/backend/common/pom.xml
@@ -15,12 +15,27 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.vodplatform</groupId>
+            <artifactId>auth</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/backend/common/src/main/resources/db/migration/V2__seed_role_user.sql
+++ b/backend/common/src/main/resources/db/migration/V2__seed_role_user.sql
@@ -1,0 +1,3 @@
+INSERT INTO roles (name)
+VALUES ('ROLE_USER')
+ON CONFLICT (name) DO NOTHING;

--- a/backend/common/src/test/java/com/vodplatform/common/AuthComponentScanTests.java
+++ b/backend/common/src/test/java/com/vodplatform/common/AuthComponentScanTests.java
@@ -1,0 +1,25 @@
+package com.vodplatform.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.vodplatform.auth.service.RegistrationService;
+import com.vodplatform.auth.web.RegistrationController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class AuthComponentScanTests {
+
+    @Autowired
+    private RegistrationService registrationService;
+
+    @Autowired
+    private RegistrationController registrationController;
+
+    @Test
+    void executableApplicationLoadsAuthComponentsFromRuntimeClasspath() {
+        assertThat(registrationService).isNotNull();
+        assertThat(registrationController).isNotNull();
+    }
+}


### PR DESCRIPTION
## What changed

- Implement POST /api/v1/auth/register with validated email, password, and displayName fields.
- Persist an ACTIVE user with a BCrypt password hash and the default ROLE_USER assignment.
- Return 201 Created with UserProfile; map validation errors to 400 and duplicate email to 409.
- Add the append-only Flyway V2 role seed and wire auth onto the executable common runtime classpath.
- Add validation, service, persistence, controller, malformed-request, and component-scan tests.

## Why

This completes Sprint 2 Issue 2.1 against the corrected frozen registration contract. Registration deliberately does not issue access tokens or refresh tokens; those remain scoped to Issue 2.2.

## Verification

- Backend Maven reactor: 12/12 modules successful.
- Tests: auth 15 plus common 3, 18 total, 0 failures/errors.
- Dependency tree: common has com.vodplatform:auth as a compile dependency.
- Executable Boot JAR contains BOOT-INF/lib/auth-0.1.0-SNAPSHOT.jar.
- Frozen identifier grep and git diff --check passed.

## Self-review checklist

- [x] Code is buildable and runnable.
- [x] Generated build and IDE files are excluded.
- [x] Commit history is clean and meaningful.
- [x] Final diff was reviewed for contract consistency, security, scope, migration safety, and runtime component scanning.
- [x] No login, JWT, refresh-token, logout, filter, RBAC, profile, or frontend scope was added.

This self-review is advisory and does not replace independent review.

Closes #17