### PR TITLE
[Feature] Implement login and JWT authentication

### DIFF
--- a/backend/auth/pom.xml
+++ b/backend/auth/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>spring-security-crypto</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/backend/auth/src/main/java/com/vodplatform/auth/config/AuthConfiguration.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/config/AuthConfiguration.java
@@ -4,11 +4,11 @@ import com.vodplatform.auth.persistence.RoleEntity;
 import com.vodplatform.auth.persistence.RoleRepository;
 import com.vodplatform.auth.persistence.UserEntity;
 import com.vodplatform.auth.persistence.UserRepository;
+import com.vodplatform.auth.security.Utf8AwareBcryptPasswordEncoder;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration(proxyBeanMethods = false)
@@ -18,6 +18,6 @@ public class AuthConfiguration {
 
     @Bean
     PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+        return new Utf8AwareBcryptPasswordEncoder();
     }
 }

--- a/backend/auth/src/main/java/com/vodplatform/auth/config/AuthConfiguration.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/config/AuthConfiguration.java
@@ -4,7 +4,7 @@ import com.vodplatform.auth.persistence.RoleEntity;
 import com.vodplatform.auth.persistence.RoleRepository;
 import com.vodplatform.auth.persistence.UserEntity;
 import com.vodplatform.auth.persistence.UserRepository;
-import com.vodplatform.auth.security.Utf8AwareBcryptPasswordEncoder;
+import com.vodplatform.auth.security.VersionedBcryptPasswordEncoder;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,6 +18,6 @@ public class AuthConfiguration {
 
     @Bean
     PasswordEncoder passwordEncoder() {
-        return new Utf8AwareBcryptPasswordEncoder();
+        return new VersionedBcryptPasswordEncoder();
     }
 }

--- a/backend/auth/src/main/java/com/vodplatform/auth/config/AuthTokenConfiguration.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/config/AuthTokenConfiguration.java
@@ -1,0 +1,42 @@
+package com.vodplatform.auth.config;
+
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import com.nimbusds.jose.proc.SecurityContext;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.time.Clock;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(AuthTokenProperties.class)
+public class AuthTokenConfiguration {
+
+    @Bean
+    Clock authClock() {
+        return Clock.systemUTC();
+    }
+
+    @Bean
+    SecureRandom authSecureRandom() {
+        return new SecureRandom();
+    }
+
+    @Bean
+    SecretKey jwtSecretKey(AuthTokenProperties properties) {
+        return new SecretKeySpec(
+                properties.secret().getBytes(StandardCharsets.UTF_8),
+                "HmacSHA256"
+        );
+    }
+
+    @Bean
+    JwtEncoder jwtEncoder(SecretKey jwtSecretKey) {
+        return new NimbusJwtEncoder(new ImmutableSecret<SecurityContext>(jwtSecretKey));
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/config/AuthTokenProperties.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/config/AuthTokenProperties.java
@@ -1,0 +1,29 @@
+package com.vodplatform.auth.config;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "auth.tokens")
+public record AuthTokenProperties(
+        String secret,
+        Duration accessTokenTtl,
+        Duration refreshTokenTtl
+) {
+
+    private static final int MINIMUM_HS256_SECRET_BYTES = 32;
+
+    public AuthTokenProperties {
+        if (secret == null
+                || secret.isBlank()
+                || secret.getBytes(StandardCharsets.UTF_8).length < MINIMUM_HS256_SECRET_BYTES) {
+            throw new IllegalArgumentException("JWT secret must contain at least 32 UTF-8 bytes");
+        }
+        if (accessTokenTtl == null || accessTokenTtl.isZero() || accessTokenTtl.isNegative()) {
+            throw new IllegalArgumentException("Access token TTL must be positive");
+        }
+        if (refreshTokenTtl == null || refreshTokenTtl.isZero() || refreshTokenTtl.isNegative()) {
+            throw new IllegalArgumentException("Refresh token TTL must be positive");
+        }
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/dto/AuthResponse.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/dto/AuthResponse.java
@@ -1,0 +1,9 @@
+package com.vodplatform.auth.dto;
+
+public record AuthResponse(
+        UserProfile user,
+        String accessToken,
+        String refreshToken,
+        long expiresInSeconds
+) {
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/dto/LoginRequest.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/dto/LoginRequest.java
@@ -1,0 +1,11 @@
+package com.vodplatform.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record LoginRequest(
+        @NotBlank @Email @Size(max = 320) String email,
+        @NotBlank String password
+) {
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/exception/AuthExceptionHandler.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/exception/AuthExceptionHandler.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
-public class RegistrationExceptionHandler {
+public class AuthExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException exception) {
@@ -33,6 +33,16 @@ public class RegistrationExceptionHandler {
         return buildResponse(
                 HttpStatus.CONFLICT,
                 "EMAIL_ALREADY_EXISTS",
+                exception.getMessage(),
+                List.of()
+        );
+    }
+
+    @ExceptionHandler(InvalidCredentialsException.class)
+    ResponseEntity<ApiError> handleInvalidCredentials(InvalidCredentialsException exception) {
+        return buildResponse(
+                HttpStatus.UNAUTHORIZED,
+                "INVALID_CREDENTIALS",
                 exception.getMessage(),
                 List.of()
         );

--- a/backend/auth/src/main/java/com/vodplatform/auth/exception/InvalidCredentialsException.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/exception/InvalidCredentialsException.java
@@ -1,0 +1,8 @@
+package com.vodplatform.auth.exception;
+
+public class InvalidCredentialsException extends RuntimeException {
+
+    public InvalidCredentialsException() {
+        super("Invalid email or password");
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/persistence/RefreshTokenEntity.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/persistence/RefreshTokenEntity.java
@@ -1,0 +1,77 @@
+package com.vodplatform.auth.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "refresh_tokens")
+public class RefreshTokenEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    @Column(name = "token_hash", nullable = false, unique = true, length = 255)
+    private String tokenHash;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "revoked_at")
+    private Instant revokedAt;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    protected RefreshTokenEntity() {
+    }
+
+    public RefreshTokenEntity(
+            UUID id,
+            UserEntity user,
+            String tokenHash,
+            Instant expiresAt,
+            Instant createdAt
+    ) {
+        this.id = id;
+        this.user = user;
+        this.tokenHash = tokenHash;
+        this.expiresAt = expiresAt;
+        this.createdAt = createdAt;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UserEntity getUser() {
+        return user;
+    }
+
+    public String getTokenHash() {
+        return tokenHash;
+    }
+
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    public Instant getRevokedAt() {
+        return revokedAt;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/persistence/RefreshTokenRepository.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/persistence/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.vodplatform.auth.persistence;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity, UUID> {
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/persistence/UserEntity.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/persistence/UserEntity.java
@@ -75,6 +75,11 @@ public class UserEntity {
         roles.add(role);
     }
 
+    public void updatePasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+        this.updatedAt = Instant.now();
+    }
+
     public UUID getId() {
         return id;
     }

--- a/backend/auth/src/main/java/com/vodplatform/auth/persistence/UserRepository.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/persistence/UserRepository.java
@@ -1,9 +1,14 @@
 package com.vodplatform.auth.persistence;
 
+import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<UserEntity, UUID> {
 
     boolean existsByEmail(String email);
+
+    @EntityGraph(attributePaths = "roles")
+    Optional<UserEntity> findByEmail(String email);
 }

--- a/backend/auth/src/main/java/com/vodplatform/auth/security/Utf8AwareBcryptPasswordEncoder.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/security/Utf8AwareBcryptPasswordEncoder.java
@@ -1,0 +1,50 @@
+package com.vodplatform.auth.security;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public final class Utf8AwareBcryptPasswordEncoder implements PasswordEncoder {
+
+    private static final String PREHASH_DOMAIN = "vod-bcrypt-sha256:";
+
+    private final BCryptPasswordEncoder delegate;
+
+    public Utf8AwareBcryptPasswordEncoder() {
+        this.delegate = new BCryptPasswordEncoder();
+    }
+
+    @Override
+    public String encode(CharSequence rawPassword) {
+        if (rawPassword == null) {
+            throw new IllegalArgumentException("Raw password cannot be null");
+        }
+        return delegate.encode(prehash(rawPassword));
+    }
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String encodedPassword) {
+        if (rawPassword == null) {
+            return false;
+        }
+        return delegate.matches(prehash(rawPassword), encodedPassword);
+    }
+
+    @Override
+    public boolean upgradeEncoding(String encodedPassword) {
+        return delegate.upgradeEncoding(encodedPassword);
+    }
+
+    private String prehash(CharSequence rawPassword) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] passwordHash = digest.digest(rawPassword.toString().getBytes(StandardCharsets.UTF_8));
+            return PREHASH_DOMAIN + Base64.getUrlEncoder().withoutPadding().encodeToString(passwordHash);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 is not available", exception);
+        }
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/security/VersionedBcryptPasswordEncoder.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/security/VersionedBcryptPasswordEncoder.java
@@ -1,0 +1,44 @@
+package com.vodplatform.auth.security;
+
+import java.util.Map;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * Writes versioned SHA-256-prehashed BCrypt values while retaining support for
+ * the unprefixed direct BCrypt hashes produced before login was implemented.
+ */
+public final class VersionedBcryptPasswordEncoder implements PasswordEncoder {
+
+    static final String CURRENT_ENCODING_ID = "bcrypt-sha256";
+
+    private final DelegatingPasswordEncoder delegate;
+
+    public VersionedBcryptPasswordEncoder() {
+        BCryptPasswordEncoder legacyBcrypt = new BCryptPasswordEncoder();
+        this.delegate = new DelegatingPasswordEncoder(
+                CURRENT_ENCODING_ID,
+                Map.of(
+                        "bcrypt", legacyBcrypt,
+                        CURRENT_ENCODING_ID, new Utf8AwareBcryptPasswordEncoder()
+                )
+        );
+        this.delegate.setDefaultPasswordEncoderForMatches(legacyBcrypt);
+    }
+
+    @Override
+    public String encode(CharSequence rawPassword) {
+        return delegate.encode(rawPassword);
+    }
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String encodedPassword) {
+        return delegate.matches(rawPassword, encodedPassword);
+    }
+
+    @Override
+    public boolean upgradeEncoding(String encodedPassword) {
+        return delegate.upgradeEncoding(encodedPassword);
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/service/IssuedAccessToken.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/service/IssuedAccessToken.java
@@ -1,0 +1,4 @@
+package com.vodplatform.auth.service;
+
+public record IssuedAccessToken(String value, long expiresInSeconds) {
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/service/IssuedRefreshToken.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/service/IssuedRefreshToken.java
@@ -1,0 +1,6 @@
+package com.vodplatform.auth.service;
+
+import java.time.Instant;
+
+public record IssuedRefreshToken(String value, String hash, Instant expiresAt) {
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/service/JwtAccessTokenService.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/service/JwtAccessTokenService.java
@@ -1,0 +1,54 @@
+package com.vodplatform.auth.service;
+
+import com.vodplatform.auth.config.AuthTokenProperties;
+import com.vodplatform.auth.persistence.RoleEntity;
+import com.vodplatform.auth.persistence.UserEntity;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtAccessTokenService {
+
+    private final JwtEncoder jwtEncoder;
+    private final AuthTokenProperties properties;
+    private final Clock clock;
+
+    public JwtAccessTokenService(JwtEncoder jwtEncoder, AuthTokenProperties properties, Clock clock) {
+        this.jwtEncoder = jwtEncoder;
+        this.properties = properties;
+        this.clock = clock;
+    }
+
+    public IssuedAccessToken issue(UserEntity user) {
+        Instant issuedAt = clock.instant();
+        Instant expiresAt = issuedAt.plus(properties.accessTokenTtl());
+        List<String> roles = user.getRoles().stream()
+                .map(RoleEntity::getName)
+                .sorted(Comparator.naturalOrder())
+                .toList();
+        String userId = user.getId().toString();
+
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .subject(userId)
+                .issuedAt(issuedAt)
+                .expiresAt(expiresAt)
+                .claim("userId", userId)
+                .claim("email", user.getEmail())
+                .claim("roles", roles)
+                .build();
+        JwsHeader header = JwsHeader.with(MacAlgorithm.HS256)
+                .type("JWT")
+                .build();
+        String value = jwtEncoder.encode(JwtEncoderParameters.from(header, claims)).getTokenValue();
+
+        return new IssuedAccessToken(value, properties.accessTokenTtl().toSeconds());
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/service/LoginService.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/service/LoginService.java
@@ -48,6 +48,10 @@ public class LoginService {
                 .filter(candidate -> candidate.getStatus() == UserStatus.ACTIVE)
                 .orElseThrow(InvalidCredentialsException::new);
 
+        if (passwordEncoder.upgradeEncoding(passwordHash)) {
+            user.updatePasswordHash(passwordEncoder.encode(request.password()));
+        }
+
         IssuedAccessToken accessToken = jwtAccessTokenService.issue(user);
         IssuedRefreshToken refreshToken = refreshTokenService.issue(user);
         return new AuthResponse(

--- a/backend/auth/src/main/java/com/vodplatform/auth/service/LoginService.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/service/LoginService.java
@@ -1,0 +1,60 @@
+package com.vodplatform.auth.service;
+
+import com.vodplatform.auth.dto.AuthResponse;
+import com.vodplatform.auth.dto.LoginRequest;
+import com.vodplatform.auth.exception.InvalidCredentialsException;
+import com.vodplatform.auth.persistence.UserEntity;
+import com.vodplatform.auth.persistence.UserRepository;
+import com.vodplatform.auth.persistence.UserStatus;
+import java.util.Optional;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class LoginService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtAccessTokenService jwtAccessTokenService;
+    private final RefreshTokenService refreshTokenService;
+    private final UserProfileMapper userProfileMapper;
+    private final String dummyPasswordHash;
+
+    public LoginService(
+            UserRepository userRepository,
+            PasswordEncoder passwordEncoder,
+            JwtAccessTokenService jwtAccessTokenService,
+            RefreshTokenService refreshTokenService,
+            UserProfileMapper userProfileMapper
+    ) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtAccessTokenService = jwtAccessTokenService;
+        this.refreshTokenService = refreshTokenService;
+        this.userProfileMapper = userProfileMapper;
+        this.dummyPasswordHash = passwordEncoder.encode("invalid-login-placeholder");
+    }
+
+    @Transactional
+    public AuthResponse login(LoginRequest request) {
+        Optional<UserEntity> userCandidate = userRepository.findByEmail(request.email());
+        String passwordHash = userCandidate
+                .map(UserEntity::getPasswordHash)
+                .orElse(dummyPasswordHash);
+        boolean passwordMatches = passwordEncoder.matches(request.password(), passwordHash);
+        UserEntity user = userCandidate
+                .filter(candidate -> passwordMatches)
+                .filter(candidate -> candidate.getStatus() == UserStatus.ACTIVE)
+                .orElseThrow(InvalidCredentialsException::new);
+
+        IssuedAccessToken accessToken = jwtAccessTokenService.issue(user);
+        IssuedRefreshToken refreshToken = refreshTokenService.issue(user);
+        return new AuthResponse(
+                userProfileMapper.toProfile(user),
+                accessToken.value(),
+                refreshToken.value(),
+                accessToken.expiresInSeconds()
+        );
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/service/RefreshTokenService.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/service/RefreshTokenService.java
@@ -1,0 +1,66 @@
+package com.vodplatform.auth.service;
+
+import com.vodplatform.auth.config.AuthTokenProperties;
+import com.vodplatform.auth.persistence.RefreshTokenEntity;
+import com.vodplatform.auth.persistence.RefreshTokenRepository;
+import com.vodplatform.auth.persistence.UserEntity;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RefreshTokenService {
+
+    private static final int TOKEN_BYTES = 32;
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final AuthTokenProperties properties;
+    private final SecureRandom secureRandom;
+    private final Clock clock;
+
+    public RefreshTokenService(
+            RefreshTokenRepository refreshTokenRepository,
+            AuthTokenProperties properties,
+            SecureRandom secureRandom,
+            Clock clock
+    ) {
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.properties = properties;
+        this.secureRandom = secureRandom;
+        this.clock = clock;
+    }
+
+    public IssuedRefreshToken issue(UserEntity user) {
+        byte[] tokenBytes = new byte[TOKEN_BYTES];
+        secureRandom.nextBytes(tokenBytes);
+        String value = Base64.getUrlEncoder().withoutPadding().encodeToString(tokenBytes);
+        String hash = hash(value);
+        Instant createdAt = clock.instant();
+        Instant expiresAt = createdAt.plus(properties.refreshTokenTtl());
+
+        refreshTokenRepository.save(new RefreshTokenEntity(
+                UUID.randomUUID(),
+                user,
+                hash,
+                expiresAt,
+                createdAt
+        ));
+        return new IssuedRefreshToken(value, hash, expiresAt);
+    }
+
+    public String hash(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 is not available", exception);
+        }
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/service/RegistrationService.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/service/RegistrationService.java
@@ -9,11 +9,9 @@ import com.vodplatform.auth.persistence.UserEntity;
 import com.vodplatform.auth.persistence.UserRepository;
 import com.vodplatform.auth.persistence.UserStatus;
 import java.time.Instant;
-import java.util.Comparator;
-import java.util.List;
 import java.util.UUID;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,15 +24,18 @@ public class RegistrationService {
     private final UserRepository userRepository;
     private final RoleRepository roleRepository;
     private final PasswordEncoder passwordEncoder;
+    private final UserProfileMapper userProfileMapper;
 
     public RegistrationService(
             UserRepository userRepository,
             RoleRepository roleRepository,
-            PasswordEncoder passwordEncoder
+            PasswordEncoder passwordEncoder,
+            UserProfileMapper userProfileMapper
     ) {
         this.userRepository = userRepository;
         this.roleRepository = roleRepository;
         this.passwordEncoder = passwordEncoder;
+        this.userProfileMapper = userProfileMapper;
     }
 
     @Transactional
@@ -59,7 +60,7 @@ public class RegistrationService {
 
         try {
             UserEntity savedUser = userRepository.saveAndFlush(user);
-            return toProfile(savedUser);
+            return userProfileMapper.toProfile(savedUser);
         } catch (DataIntegrityViolationException exception) {
             if (hasConstraint(exception, "ux_users_email")) {
                 throw new EmailAlreadyExistsException();
@@ -80,11 +81,4 @@ public class RegistrationService {
         return false;
     }
 
-    private UserProfile toProfile(UserEntity user) {
-        List<String> roles = user.getRoles().stream()
-                .map(RoleEntity::getName)
-                .sorted(Comparator.naturalOrder())
-                .toList();
-        return new UserProfile(user.getId(), user.getEmail(), user.getDisplayName(), roles);
-    }
 }

--- a/backend/auth/src/main/java/com/vodplatform/auth/service/UserProfileMapper.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/service/UserProfileMapper.java
@@ -1,0 +1,20 @@
+package com.vodplatform.auth.service;
+
+import com.vodplatform.auth.dto.UserProfile;
+import com.vodplatform.auth.persistence.RoleEntity;
+import com.vodplatform.auth.persistence.UserEntity;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserProfileMapper {
+
+    public UserProfile toProfile(UserEntity user) {
+        List<String> roles = user.getRoles().stream()
+                .map(RoleEntity::getName)
+                .sorted(Comparator.naturalOrder())
+                .toList();
+        return new UserProfile(user.getId(), user.getEmail(), user.getDisplayName(), roles);
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/web/LoginController.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/web/LoginController.java
@@ -1,0 +1,27 @@
+package com.vodplatform.auth.web;
+
+import com.vodplatform.auth.dto.AuthResponse;
+import com.vodplatform.auth.dto.LoginRequest;
+import com.vodplatform.auth.service.LoginService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class LoginController {
+
+    private final LoginService loginService;
+
+    public LoginController(LoginService loginService) {
+        this.loginService = loginService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(loginService.login(request));
+    }
+}

--- a/backend/auth/src/test/java/com/vodplatform/auth/config/AuthTokenPropertiesTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/config/AuthTokenPropertiesTest.java
@@ -1,0 +1,36 @@
+package com.vodplatform.auth.config;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class AuthTokenPropertiesTest {
+
+    @Test
+    void rejectsSecretThatIsTooShortForHs256() {
+        assertThatThrownBy(() -> new AuthTokenProperties(
+                "too-short",
+                Duration.ofMinutes(15),
+                Duration.ofDays(7)
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("at least 32");
+    }
+
+    @Test
+    void rejectsNonPositiveTokenTtls() {
+        assertThatThrownBy(() -> new AuthTokenProperties(
+                "test-only-secret-with-at-least-32-bytes",
+                Duration.ZERO,
+                Duration.ofDays(7)
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Access token TTL");
+
+        assertThatThrownBy(() -> new AuthTokenProperties(
+                "test-only-secret-with-at-least-32-bytes",
+                Duration.ofMinutes(15),
+                Duration.ofSeconds(-1)
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Refresh token TTL");
+    }
+}

--- a/backend/auth/src/test/java/com/vodplatform/auth/security/Utf8AwareBcryptPasswordEncoderTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/security/Utf8AwareBcryptPasswordEncoderTest.java
@@ -1,0 +1,29 @@
+package com.vodplatform.auth.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class Utf8AwareBcryptPasswordEncoderTest {
+
+    private final Utf8AwareBcryptPasswordEncoder passwordEncoder = new Utf8AwareBcryptPasswordEncoder();
+
+    @Test
+    void suffixBeyondBcryptByteBoundaryCannotAuthenticate() {
+        String password = "a".repeat(72);
+        String encodedPassword = passwordEncoder.encode(password);
+
+        assertThat(passwordEncoder.matches(password, encodedPassword)).isTrue();
+        assertThat(passwordEncoder.matches(password + "suffix", encodedPassword)).isFalse();
+    }
+
+    @Test
+    void supportsFullUnicodeCharacterLimitWithoutBcryptTruncation() {
+        String password = "密".repeat(72);
+        String encodedPassword = passwordEncoder.encode(password);
+
+        assertThat(password.getBytes(java.nio.charset.StandardCharsets.UTF_8).length).isGreaterThan(72);
+        assertThat(passwordEncoder.matches(password, encodedPassword)).isTrue();
+        assertThat(passwordEncoder.matches(password + "異", encodedPassword)).isFalse();
+    }
+}

--- a/backend/auth/src/test/java/com/vodplatform/auth/security/VersionedBcryptPasswordEncoderTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/security/VersionedBcryptPasswordEncoderTest.java
@@ -1,0 +1,41 @@
+package com.vodplatform.auth.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+class VersionedBcryptPasswordEncoderTest {
+
+    private final VersionedBcryptPasswordEncoder passwordEncoder =
+            new VersionedBcryptPasswordEncoder();
+
+    @Test
+    void authenticatesLegacyDirectBcryptHashesAndMarksThemForUpgrade() {
+        String password = "legacy-password";
+        String legacyHash = new BCryptPasswordEncoder().encode(password);
+
+        assertThat(passwordEncoder.matches(password, legacyHash)).isTrue();
+        assertThat(passwordEncoder.matches("wrong-password", legacyHash)).isFalse();
+        assertThat(passwordEncoder.upgradeEncoding(legacyHash)).isTrue();
+    }
+
+    @Test
+    void createsVersionedBcryptHashesThatDoNotNeedUpgrade() {
+        String encodedPassword = passwordEncoder.encode("new-password");
+
+        assertThat(encodedPassword).startsWith("{bcrypt-sha256}$2");
+        assertThat(passwordEncoder.matches("new-password", encodedPassword)).isTrue();
+        assertThat(passwordEncoder.matches("wrong-password", encodedPassword)).isFalse();
+        assertThat(passwordEncoder.upgradeEncoding(encodedPassword)).isFalse();
+    }
+
+    @Test
+    void preservesAllUtf8PasswordBytesForNewHashes() {
+        String password = "密".repeat(72);
+        String encodedPassword = passwordEncoder.encode(password);
+
+        assertThat(passwordEncoder.matches(password, encodedPassword)).isTrue();
+        assertThat(passwordEncoder.matches(password + "異", encodedPassword)).isFalse();
+    }
+}

--- a/backend/auth/src/test/java/com/vodplatform/auth/security/VersionedBcryptPasswordEncoderTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/security/VersionedBcryptPasswordEncoderTest.java
@@ -21,6 +21,16 @@ class VersionedBcryptPasswordEncoderTest {
     }
 
     @Test
+    void authenticatesExplicitDirectBcryptHashesAndMarksThemForUpgrade() {
+        String password = "prefixed-password";
+        String directBcryptHash = "{bcrypt}" + new BCryptPasswordEncoder().encode(password);
+
+        assertThat(passwordEncoder.matches(password, directBcryptHash)).isTrue();
+        assertThat(passwordEncoder.matches("wrong-password", directBcryptHash)).isFalse();
+        assertThat(passwordEncoder.upgradeEncoding(directBcryptHash)).isTrue();
+    }
+
+    @Test
     void createsVersionedBcryptHashesThatDoNotNeedUpgrade() {
         String encodedPassword = passwordEncoder.encode("new-password");
 

--- a/backend/auth/src/test/java/com/vodplatform/auth/service/JwtAccessTokenServiceTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/service/JwtAccessTokenServiceTest.java
@@ -1,0 +1,72 @@
+package com.vodplatform.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.vodplatform.auth.config.AuthTokenProperties;
+import com.vodplatform.auth.persistence.RoleEntity;
+import com.vodplatform.auth.persistence.UserEntity;
+import com.vodplatform.auth.persistence.UserStatus;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+
+class JwtAccessTokenServiceTest {
+
+    private static final String SECRET = "test-only-secret-with-at-least-32-bytes";
+
+    @Test
+    void issuesSignedJwtWithFrozenUserClaimsAndConfiguredExpiration() {
+        Instant issuedAt = Instant.now().truncatedTo(java.time.temporal.ChronoUnit.SECONDS);
+        Clock clock = Clock.fixed(issuedAt, ZoneOffset.UTC);
+        AuthTokenProperties properties = new AuthTokenProperties(
+                SECRET,
+                Duration.ofMinutes(15),
+                Duration.ofDays(7)
+        );
+        SecretKey secretKey = new SecretKeySpec(SECRET.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        NimbusJwtEncoder encoder = new NimbusJwtEncoder(new ImmutableSecret<SecurityContext>(secretKey));
+        JwtAccessTokenService service = new JwtAccessTokenService(encoder, properties, clock);
+        RoleEntity role = mock(RoleEntity.class);
+        when(role.getName()).thenReturn("ROLE_USER");
+        UUID userId = UUID.randomUUID();
+        UserEntity user = new UserEntity(
+                userId,
+                "viewer@example.com",
+                "bcrypt-hash",
+                "Viewer",
+                UserStatus.ACTIVE,
+                issuedAt,
+                issuedAt
+        );
+        user.addRole(role);
+
+        IssuedAccessToken issuedToken = service.issue(user);
+
+        Jwt jwt = NimbusJwtDecoder.withSecretKey(secretKey)
+                .macAlgorithm(MacAlgorithm.HS256)
+                .build()
+                .decode(issuedToken.value());
+        assertThat(jwt.getSubject()).isEqualTo(userId.toString());
+        assertThat(jwt.getClaimAsString("userId")).isEqualTo(userId.toString());
+        assertThat(jwt.getClaimAsString("email")).isEqualTo("viewer@example.com");
+        assertThat(jwt.getClaimAsStringList("roles")).isEqualTo(List.of("ROLE_USER"));
+        assertThat(jwt.getIssuedAt()).isEqualTo(issuedAt);
+        assertThat(jwt.getExpiresAt()).isEqualTo(issuedAt.plus(Duration.ofMinutes(15)));
+        assertThat(issuedToken.expiresInSeconds()).isEqualTo(900);
+    }
+}

--- a/backend/auth/src/test/java/com/vodplatform/auth/service/LoginServiceTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/service/LoginServiceTest.java
@@ -90,6 +90,34 @@ class LoginServiceTest {
     }
 
     @Test
+    void upgradesLegacyPasswordHashAfterSuccessfulAuthentication() {
+        LoginRequest request = new LoginRequest("viewer@example.com", "correct-password");
+        UserProfile profile = new UserProfile(
+                UUID.randomUUID(),
+                request.email(),
+                "Viewer",
+                List.of("ROLE_USER")
+        );
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
+        when(user.getPasswordHash()).thenReturn("legacy-bcrypt-hash");
+        when(user.getStatus()).thenReturn(UserStatus.ACTIVE);
+        when(passwordEncoder.matches(request.password(), "legacy-bcrypt-hash")).thenReturn(true);
+        when(passwordEncoder.upgradeEncoding("legacy-bcrypt-hash")).thenReturn(true);
+        when(passwordEncoder.encode(request.password())).thenReturn("versioned-bcrypt-hash");
+        when(jwtAccessTokenService.issue(user)).thenReturn(new IssuedAccessToken("access-token", 900));
+        when(refreshTokenService.issue(user)).thenReturn(new IssuedRefreshToken(
+                "refresh-token",
+                "refresh-hash",
+                Instant.parse("2030-01-08T00:00:00Z")
+        ));
+        when(userProfileMapper.toProfile(user)).thenReturn(profile);
+
+        loginService.login(request);
+
+        verify(user).updatePasswordHash("versioned-bcrypt-hash");
+    }
+
+    @Test
     void unknownEmailUsesDummyHashAndReturnsGenericFailure() {
         LoginRequest request = new LoginRequest("missing@example.com", "wrong-password");
         when(userRepository.findByEmail(request.email())).thenReturn(Optional.empty());

--- a/backend/auth/src/test/java/com/vodplatform/auth/service/LoginServiceTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/service/LoginServiceTest.java
@@ -1,0 +1,129 @@
+package com.vodplatform.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.vodplatform.auth.dto.AuthResponse;
+import com.vodplatform.auth.dto.LoginRequest;
+import com.vodplatform.auth.dto.UserProfile;
+import com.vodplatform.auth.exception.InvalidCredentialsException;
+import com.vodplatform.auth.persistence.UserEntity;
+import com.vodplatform.auth.persistence.UserRepository;
+import com.vodplatform.auth.persistence.UserStatus;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class LoginServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtAccessTokenService jwtAccessTokenService;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private UserProfileMapper userProfileMapper;
+
+    @Mock
+    private UserEntity user;
+
+    private LoginService loginService;
+
+    @BeforeEach
+    void setUp() {
+        when(passwordEncoder.encode(anyString())).thenReturn("dummy-hash");
+        loginService = new LoginService(
+                userRepository,
+                passwordEncoder,
+                jwtAccessTokenService,
+                refreshTokenService,
+                userProfileMapper
+        );
+    }
+
+    @Test
+    void returnsUserAndBothTokensForValidActiveUser() {
+        LoginRequest request = new LoginRequest("viewer@example.com", "correct-password");
+        UserProfile profile = new UserProfile(
+                UUID.randomUUID(),
+                request.email(),
+                "Viewer",
+                List.of("ROLE_USER")
+        );
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
+        when(user.getPasswordHash()).thenReturn("stored-bcrypt-hash");
+        when(user.getStatus()).thenReturn(UserStatus.ACTIVE);
+        when(passwordEncoder.matches(request.password(), "stored-bcrypt-hash")).thenReturn(true);
+        when(jwtAccessTokenService.issue(user)).thenReturn(new IssuedAccessToken("access-token", 900));
+        when(refreshTokenService.issue(user)).thenReturn(new IssuedRefreshToken(
+                "refresh-token",
+                "refresh-hash",
+                Instant.parse("2030-01-08T00:00:00Z")
+        ));
+        when(userProfileMapper.toProfile(user)).thenReturn(profile);
+
+        AuthResponse response = loginService.login(request);
+
+        assertThat(response.user()).isEqualTo(profile);
+        assertThat(response.accessToken()).isEqualTo("access-token");
+        assertThat(response.refreshToken()).isEqualTo("refresh-token");
+        assertThat(response.expiresInSeconds()).isEqualTo(900);
+    }
+
+    @Test
+    void unknownEmailUsesDummyHashAndReturnsGenericFailure() {
+        LoginRequest request = new LoginRequest("missing@example.com", "wrong-password");
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.empty());
+        when(passwordEncoder.matches(request.password(), "dummy-hash")).thenReturn(false);
+
+        assertGenericFailure(request);
+        verify(jwtAccessTokenService, never()).issue(user);
+        verify(refreshTokenService, never()).issue(user);
+    }
+
+    @Test
+    void wrongPasswordReturnsSameGenericFailure() {
+        LoginRequest request = new LoginRequest("viewer@example.com", "wrong-password");
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
+        when(user.getPasswordHash()).thenReturn("stored-bcrypt-hash");
+        when(passwordEncoder.matches(request.password(), "stored-bcrypt-hash")).thenReturn(false);
+
+        assertGenericFailure(request);
+    }
+
+    @Test
+    void disabledUserReturnsSameGenericFailure() {
+        LoginRequest request = new LoginRequest("viewer@example.com", "correct-password");
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
+        when(user.getPasswordHash()).thenReturn("stored-bcrypt-hash");
+        when(user.getStatus()).thenReturn(UserStatus.DISABLED);
+        when(passwordEncoder.matches(request.password(), "stored-bcrypt-hash")).thenReturn(true);
+
+        assertGenericFailure(request);
+    }
+
+    private void assertGenericFailure(LoginRequest request) {
+        assertThatThrownBy(() -> loginService.login(request))
+                .isInstanceOf(InvalidCredentialsException.class)
+                .hasMessage("Invalid email or password");
+    }
+}

--- a/backend/auth/src/test/java/com/vodplatform/auth/service/RefreshTokenServiceTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/service/RefreshTokenServiceTest.java
@@ -1,0 +1,61 @@
+package com.vodplatform.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.vodplatform.auth.config.AuthTokenProperties;
+import com.vodplatform.auth.persistence.RefreshTokenEntity;
+import com.vodplatform.auth.persistence.RefreshTokenRepository;
+import com.vodplatform.auth.persistence.UserEntity;
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class RefreshTokenServiceTest {
+
+    @Test
+    void returnsOpaqueTokenAndPersistsOnlyItsHashWithExpiration() {
+        RefreshTokenRepository repository = mock(RefreshTokenRepository.class);
+        SecureRandom secureRandom = mock(SecureRandom.class);
+        doAnswer(invocation -> {
+            byte[] bytes = invocation.getArgument(0);
+            Arrays.fill(bytes, (byte) 0x5a);
+            return null;
+        }).when(secureRandom).nextBytes(any(byte[].class));
+        Instant createdAt = Instant.parse("2030-01-01T00:00:00Z");
+        AuthTokenProperties properties = new AuthTokenProperties(
+                "test-only-secret-with-at-least-32-bytes",
+                Duration.ofMinutes(15),
+                Duration.ofDays(7)
+        );
+        RefreshTokenService service = new RefreshTokenService(
+                repository,
+                properties,
+                secureRandom,
+                Clock.fixed(createdAt, ZoneOffset.UTC)
+        );
+        UserEntity user = mock(UserEntity.class);
+
+        IssuedRefreshToken issuedToken = service.issue(user);
+
+        ArgumentCaptor<RefreshTokenEntity> entityCaptor = ArgumentCaptor.forClass(RefreshTokenEntity.class);
+        verify(repository).save(entityCaptor.capture());
+        RefreshTokenEntity storedToken = entityCaptor.getValue();
+        assertThat(issuedToken.value()).hasSize(43);
+        assertThat(issuedToken.hash()).isEqualTo(service.hash(issuedToken.value()));
+        assertThat(storedToken.getTokenHash()).isEqualTo(issuedToken.hash());
+        assertThat(storedToken.getTokenHash()).isNotEqualTo(issuedToken.value());
+        assertThat(storedToken.getUser()).isSameAs(user);
+        assertThat(storedToken.getCreatedAt()).isEqualTo(createdAt);
+        assertThat(storedToken.getExpiresAt()).isEqualTo(createdAt.plus(Duration.ofDays(7)));
+        assertThat(storedToken.getRevokedAt()).isNull();
+    }
+}

--- a/backend/auth/src/test/java/com/vodplatform/auth/service/RegistrationServiceTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/service/RegistrationServiceTest.java
@@ -15,9 +15,9 @@ import com.vodplatform.auth.persistence.RoleRepository;
 import com.vodplatform.auth.persistence.UserEntity;
 import com.vodplatform.auth.persistence.UserRepository;
 import com.vodplatform.auth.persistence.UserStatus;
-import com.vodplatform.auth.security.Utf8AwareBcryptPasswordEncoder;
-import java.util.Optional;
+import com.vodplatform.auth.security.VersionedBcryptPasswordEncoder;
 import java.sql.SQLException;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,7 +46,7 @@ class RegistrationServiceTest {
 
     @BeforeEach
     void setUp() {
-        passwordEncoder = new Utf8AwareBcryptPasswordEncoder();
+        passwordEncoder = new VersionedBcryptPasswordEncoder();
         userProfileMapper = new UserProfileMapper();
         registrationService = new RegistrationService(
                 userRepository,
@@ -79,6 +79,7 @@ class RegistrationServiceTest {
         assertThat(savedUser.getStatus()).isEqualTo(UserStatus.ACTIVE);
         assertThat(savedUser.getRoles()).containsExactly(role);
         assertThat(savedUser.getPasswordHash()).isNotEqualTo(request.password());
+        assertThat(savedUser.getPasswordHash()).startsWith("{bcrypt-sha256}$2");
         assertThat(passwordEncoder.matches(request.password(), savedUser.getPasswordHash())).isTrue();
         assertThat(profile.id()).isEqualTo(savedUser.getId());
         assertThat(profile.email()).isEqualTo(request.email());

--- a/backend/auth/src/test/java/com/vodplatform/auth/service/RegistrationServiceTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/service/RegistrationServiceTest.java
@@ -15,6 +15,7 @@ import com.vodplatform.auth.persistence.RoleRepository;
 import com.vodplatform.auth.persistence.UserEntity;
 import com.vodplatform.auth.persistence.UserRepository;
 import com.vodplatform.auth.persistence.UserStatus;
+import com.vodplatform.auth.security.Utf8AwareBcryptPasswordEncoder;
 import java.util.Optional;
 import java.sql.SQLException;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +25,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.hibernate.exception.ConstraintViolationException;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,13 +40,20 @@ class RegistrationServiceTest {
     @Mock
     private RoleEntity role;
 
-    private BCryptPasswordEncoder passwordEncoder;
+    private PasswordEncoder passwordEncoder;
     private RegistrationService registrationService;
+    private UserProfileMapper userProfileMapper;
 
     @BeforeEach
     void setUp() {
-        passwordEncoder = new BCryptPasswordEncoder();
-        registrationService = new RegistrationService(userRepository, roleRepository, passwordEncoder);
+        passwordEncoder = new Utf8AwareBcryptPasswordEncoder();
+        userProfileMapper = new UserProfileMapper();
+        registrationService = new RegistrationService(
+                userRepository,
+                roleRepository,
+                passwordEncoder,
+                userProfileMapper
+        );
     }
 
     @Test

--- a/backend/auth/src/test/java/com/vodplatform/auth/web/LoginControllerTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/web/LoginControllerTest.java
@@ -1,0 +1,111 @@
+package com.vodplatform.auth.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.vodplatform.auth.dto.AuthResponse;
+import com.vodplatform.auth.dto.LoginRequest;
+import com.vodplatform.auth.dto.UserProfile;
+import com.vodplatform.auth.exception.AuthExceptionHandler;
+import com.vodplatform.auth.exception.InvalidCredentialsException;
+import com.vodplatform.auth.service.LoginService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+@ExtendWith(MockitoExtension.class)
+class LoginControllerTest {
+
+    @Mock
+    private LoginService loginService;
+
+    private LocalValidatorFactoryBean validator;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new LoginController(loginService))
+                .setControllerAdvice(new AuthExceptionHandler())
+                .setValidator(validator)
+                .build();
+    }
+
+    @AfterEach
+    void closeValidatorFactory() {
+        validator.close();
+    }
+
+    @Test
+    void returnsAuthResponseForValidCredentials() throws Exception {
+        UUID userId = UUID.randomUUID();
+        when(loginService.login(any(LoginRequest.class))).thenReturn(new AuthResponse(
+                new UserProfile(userId, "viewer@example.com", "Viewer", List.of("ROLE_USER")),
+                "signed-access-token",
+                "opaque-refresh-token",
+                900
+        ));
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "viewer@example.com",
+                                  "password": "strong-password"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user.id").value(userId.toString()))
+                .andExpect(jsonPath("$.user.roles[0]").value("ROLE_USER"))
+                .andExpect(jsonPath("$.accessToken").value("signed-access-token"))
+                .andExpect(jsonPath("$.refreshToken").value("opaque-refresh-token"))
+                .andExpect(jsonPath("$.expiresInSeconds").value(900));
+    }
+
+    @Test
+    void returnsGenericUnauthorizedResponseForInvalidCredentials() throws Exception {
+        when(loginService.login(any(LoginRequest.class))).thenThrow(new InvalidCredentialsException());
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "viewer@example.com",
+                                  "password": "wrong-password"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.code").value("INVALID_CREDENTIALS"))
+                .andExpect(jsonPath("$.message").value("Invalid email or password"));
+    }
+
+    @Test
+    void returnsValidationErrorForMalformedLoginFields() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "not-an-email",
+                                  "password": ""
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+}

--- a/backend/auth/src/test/java/com/vodplatform/auth/web/RegistrationControllerTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/web/RegistrationControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.vodplatform.auth.dto.RegisterRequest;
 import com.vodplatform.auth.dto.UserProfile;
 import com.vodplatform.auth.exception.EmailAlreadyExistsException;
-import com.vodplatform.auth.exception.RegistrationExceptionHandler;
+import com.vodplatform.auth.exception.AuthExceptionHandler;
 import com.vodplatform.auth.service.RegistrationService;
 import java.util.List;
 import java.util.UUID;
@@ -39,7 +39,7 @@ class RegistrationControllerTest {
         validator.afterPropertiesSet();
         mockMvc = MockMvcBuilders
                 .standaloneSetup(new RegistrationController(registrationService))
-                .setControllerAdvice(new RegistrationExceptionHandler())
+                .setControllerAdvice(new AuthExceptionHandler())
                 .setValidator(validator)
                 .build();
     }

--- a/backend/common/src/main/resources/application.yml
+++ b/backend/common/src/main/resources/application.yml
@@ -5,6 +5,12 @@ spring:
   application:
     name: vod-backend
 
+auth:
+  tokens:
+    secret: ${JWT_SECRET}
+    access-token-ttl: ${JWT_ACCESS_TOKEN_TTL_MINUTES:60}m
+    refresh-token-ttl: ${JWT_REFRESH_TOKEN_TTL_DAYS:7}d
+
 management:
   endpoints:
     web:

--- a/backend/common/src/test/java/com/vodplatform/common/AuthComponentScanTests.java
+++ b/backend/common/src/test/java/com/vodplatform/common/AuthComponentScanTests.java
@@ -2,13 +2,18 @@ package com.vodplatform.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.vodplatform.auth.service.LoginService;
 import com.vodplatform.auth.service.RegistrationService;
+import com.vodplatform.auth.web.LoginController;
 import com.vodplatform.auth.web.RegistrationController;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        properties = "auth.tokens.secret=test-only-secret-with-at-least-32-bytes"
+)
 class AuthComponentScanTests {
 
     @Autowired
@@ -17,9 +22,17 @@ class AuthComponentScanTests {
     @Autowired
     private RegistrationController registrationController;
 
+    @Autowired
+    private LoginService loginService;
+
+    @Autowired
+    private LoginController loginController;
+
     @Test
     void executableApplicationLoadsAuthComponentsFromRuntimeClasspath() {
         assertThat(registrationService).isNotNull();
         assertThat(registrationController).isNotNull();
+        assertThat(loginService).isNotNull();
+        assertThat(loginController).isNotNull();
     }
 }

--- a/backend/common/src/test/java/com/vodplatform/common/LoginIntegrationTests.java
+++ b/backend/common/src/test/java/com/vodplatform/common/LoginIntegrationTests.java
@@ -17,6 +17,7 @@ import com.vodplatform.auth.persistence.UserStatus;
 import com.vodplatform.auth.service.RefreshTokenService;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,9 +61,6 @@ class LoginIntegrationTests {
     private RefreshTokenRepository refreshTokenRepository;
 
     @Autowired
-    private PasswordEncoder passwordEncoder;
-
-    @Autowired
     private RefreshTokenService refreshTokenService;
 
     @BeforeEach
@@ -73,7 +71,7 @@ class LoginIntegrationTests {
         UserEntity user = new UserEntity(
                 UUID.randomUUID(),
                 "viewer@example.com",
-                passwordEncoder.encode("strong-password"),
+                new BCryptPasswordEncoder().encode("strong-password"),
                 "Viewer",
                 UserStatus.ACTIVE,
                 now,
@@ -84,7 +82,7 @@ class LoginIntegrationTests {
     }
 
     @Test
-    void loginReturnsTokensAndPersistsOnlyRefreshTokenHash() throws Exception {
+    void legacyDirectBcryptLoginReturnsTokensAndUpgradesPasswordHash() throws Exception {
         MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
@@ -110,6 +108,39 @@ class LoginIntegrationTests {
         assertThat(storedToken.getTokenHash()).isNotEqualTo(rawRefreshToken);
         assertThat(storedToken.getExpiresAt()).isAfter(Instant.now().plusSeconds(6 * 24 * 60 * 60));
         assertThat(storedToken.getRevokedAt()).isNull();
+        assertThat(userRepository.findByEmail("viewer@example.com").orElseThrow().getPasswordHash())
+                .startsWith("{bcrypt-sha256}$2");
+    }
+
+    @Test
+    void registrationAndLoginSupportFullUnicodeCharacterLimit() throws Exception {
+        String password = "密".repeat(72);
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of(
+                                "email", "unicode@example.com",
+                                "password", password,
+                                "displayName", "Unicode Viewer"
+                        ))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.email").value("unicode@example.com"))
+                .andExpect(jsonPath("$.accessToken").doesNotExist())
+                .andExpect(jsonPath("$.refreshToken").doesNotExist());
+
+        assertThat(userRepository.findByEmail("unicode@example.com").orElseThrow().getPasswordHash())
+                .startsWith("{bcrypt-sha256}$2");
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of(
+                                "email", "unicode@example.com",
+                                "password", password
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user.email").value("unicode@example.com"))
+                .andExpect(jsonPath("$.accessToken").isString())
+                .andExpect(jsonPath("$.refreshToken").isString());
     }
 
     @Test

--- a/backend/common/src/test/java/com/vodplatform/common/LoginIntegrationTests.java
+++ b/backend/common/src/test/java/com/vodplatform/common/LoginIntegrationTests.java
@@ -1,0 +1,148 @@
+package com.vodplatform.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vodplatform.auth.persistence.RefreshTokenEntity;
+import com.vodplatform.auth.persistence.RefreshTokenRepository;
+import com.vodplatform.auth.persistence.RoleEntity;
+import com.vodplatform.auth.persistence.RoleRepository;
+import com.vodplatform.auth.persistence.UserEntity;
+import com.vodplatform.auth.persistence.UserRepository;
+import com.vodplatform.auth.persistence.UserStatus;
+import com.vodplatform.auth.service.RefreshTokenService;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest(
+        properties = {
+                "auth.tokens.secret=test-only-secret-with-at-least-32-bytes",
+                "auth.tokens.access-token-ttl=15m",
+                "auth.tokens.refresh-token-ttl=7d"
+        }
+)
+@AutoConfigureMockMvc
+@Transactional
+class LoginIntegrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private RefreshTokenService refreshTokenService;
+
+    @BeforeEach
+    void createRegisteredUser() {
+        jdbcTemplate.update("INSERT INTO roles (name) VALUES (?)", "ROLE_USER");
+        RoleEntity role = roleRepository.findByName("ROLE_USER").orElseThrow();
+        Instant now = Instant.now();
+        UserEntity user = new UserEntity(
+                UUID.randomUUID(),
+                "viewer@example.com",
+                passwordEncoder.encode("strong-password"),
+                "Viewer",
+                UserStatus.ACTIVE,
+                now,
+                now
+        );
+        user.addRole(role);
+        userRepository.saveAndFlush(user);
+    }
+
+    @Test
+    void loginReturnsTokensAndPersistsOnlyRefreshTokenHash() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "viewer@example.com",
+                                  "password": "strong-password"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user.email").value("viewer@example.com"))
+                .andExpect(jsonPath("$.user.roles[0]").value("ROLE_USER"))
+                .andExpect(jsonPath("$.accessToken").isString())
+                .andExpect(jsonPath("$.refreshToken").isString())
+                .andExpect(jsonPath("$.expiresInSeconds").value(900))
+                .andReturn();
+
+        JsonNode response = objectMapper.readTree(result.getResponse().getContentAsByteArray());
+        String rawRefreshToken = response.path("refreshToken").asText();
+        List<RefreshTokenEntity> storedTokens = refreshTokenRepository.findAll();
+        assertThat(storedTokens).hasSize(1);
+        RefreshTokenEntity storedToken = storedTokens.getFirst();
+        assertThat(storedToken.getTokenHash()).isEqualTo(refreshTokenService.hash(rawRefreshToken));
+        assertThat(storedToken.getTokenHash()).isNotEqualTo(rawRefreshToken);
+        assertThat(storedToken.getExpiresAt()).isAfter(Instant.now().plusSeconds(6 * 24 * 60 * 60));
+        assertThat(storedToken.getRevokedAt()).isNull();
+    }
+
+    @Test
+    void unknownEmailAndWrongPasswordReturnIndistinguishableUnauthorizedErrors() throws Exception {
+        String wrongPasswordResponse = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "viewer@example.com",
+                                  "password": "wrong-password"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        String unknownEmailResponse = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "missing@example.com",
+                                  "password": "wrong-password"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode wrongPasswordError = objectMapper.readTree(wrongPasswordResponse);
+        JsonNode unknownEmailError = objectMapper.readTree(unknownEmailResponse);
+        assertThat(wrongPasswordError.path("status")).isEqualTo(unknownEmailError.path("status"));
+        assertThat(wrongPasswordError.path("code")).isEqualTo(unknownEmailError.path("code"));
+        assertThat(wrongPasswordError.path("message")).isEqualTo(unknownEmailError.path("message"));
+    }
+}

--- a/backend/common/src/test/java/com/vodplatform/common/VodBackendApplicationTests.java
+++ b/backend/common/src/test/java/com/vodplatform/common/VodBackendApplicationTests.java
@@ -11,7 +11,10 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = "auth.tokens.secret=test-only-secret-with-at-least-32-bytes"
+)
 class VodBackendApplicationTests {
 
     private final TestRestTemplate restTemplate;


### PR DESCRIPTION
## What changed
- implement `POST /api/v1/auth/login` with validated DTOs and a generic `401` failure contract
- issue HS256 access JWTs containing user ID, email, and sorted roles with environment-backed expiry
- generate 256-bit opaque refresh tokens, persist only SHA-256 hashes in `refresh_tokens`, and return plaintext once in JSON
- add versioned BCrypt encoding for new credentials while preserving and upgrading direct BCrypt hashes created by merged Issue #17
- share `UserProfile` mapping and add unit, web, persistence, runtime composition, and end-to-end login tests

## Why
This completes Sprint 2 Issue 2.2 while preserving refresh validation/rotation for #19 and bearer authentication/filtering for #21. The compatibility correction prevents PR #30 from locking out accounts registered by the already-merged Issue #17 implementation.

## Important decisions
- `JWT_SECRET` is required at runtime and must contain at least 32 UTF-8 bytes; HS256 is the smallest design consistent with the frozen shared-secret contract.
- Access tokens use standard `sub`, `iat`, and `exp` claims plus explicit `userId`, `email`, and `roles` claims.
- Refresh tokens use 32 random bytes encoded as Base64URL; only a deterministic SHA-256 hash is stored so #19 can perform indexed lookup.
- New password hashes use Spring's delegating format `{bcrypt-sha256}$2...`: BCrypt receives a domain-separated SHA-256 representation of the complete UTF-8 password, avoiding BCrypt's 72-byte truncation.
- Unprefixed `$2...` hashes from merged Issue #17 are matched with direct BCrypt and upgraded transactionally to the versioned format after successful authentication.
- A read-only local persistence audit found no running database and the named Compose PostgreSQL volume predates Issue #17; compatibility is retained because unused anonymous volumes could not be proven empty without mounting them.
- Schema-invalid login requests use the existing validation `400`; well-formed invalid credentials and disabled accounts use the same generic `401` response.

## Verification
- `mvn verify` — PASS, all 12 backend reactor modules
- auth tests: 33 passed
- common runtime/integration tests: 6 passed
- regression evidence: explicit legacy direct-BCrypt seed authenticates and upgrades; 72-character Unicode registration then login succeeds
- `git diff --check` — PASS before commit
- literal contract audit against BACKLOG, API-CONTRACT, SECURITY, ERD, `.env.example`, and Compose — PASS
- future-scope guard: no refresh/logout endpoint, `SecurityFilterChain`, bearer filter, or runtime `JwtDecoder`

## Self-review
- [x] Code is buildable and runnable with required environment configuration.
- [x] Build/IDE artifacts (`target/`, `.idea/`, `*.iml`) are excluded from the diff.
- [x] Commit history is clean and meaningful.
- [x] Reviewed legacy compatibility, Unicode behavior, correctness, token secrecy, generic authentication failures, persistence ownership, transaction boundary, module classpath, query behavior, data exposure, and Issue 2.2 scope.
- [x] Independent read-only review found no blocking or actionable issue in the compatibility correction.
- [x] This self-review is not a substitute for independent review; this PR remains Draft and unmerged.

Closes #18