### PR TITLE
[Feature] Implement refresh token rotation

### DIFF
--- a/backend/auth/src/main/java/com/vodplatform/auth/dto/RefreshRequest.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/dto/RefreshRequest.java
@@ -1,0 +1,8 @@
+package com.vodplatform.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequest(
+        @NotBlank String refreshToken
+) {
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/exception/AuthExceptionHandler.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/exception/AuthExceptionHandler.java
@@ -48,6 +48,16 @@ public class AuthExceptionHandler {
         );
     }
 
+    @ExceptionHandler(InvalidRefreshTokenException.class)
+    ResponseEntity<ApiError> handleInvalidRefreshToken(InvalidRefreshTokenException exception) {
+        return buildResponse(
+                HttpStatus.UNAUTHORIZED,
+                "INVALID_REFRESH_TOKEN",
+                exception.getMessage(),
+                List.of()
+        );
+    }
+
     @ExceptionHandler(HttpMessageNotReadableException.class)
     ResponseEntity<ApiError> handleUnreadableRequest() {
         return buildResponse(

--- a/backend/auth/src/main/java/com/vodplatform/auth/exception/InvalidRefreshTokenException.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,8 @@
+package com.vodplatform.auth.exception;
+
+public class InvalidRefreshTokenException extends RuntimeException {
+
+    public InvalidRefreshTokenException() {
+        super("Invalid refresh token");
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/persistence/RefreshTokenEntity.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/persistence/RefreshTokenEntity.java
@@ -74,4 +74,8 @@ public class RefreshTokenEntity {
     public Instant getCreatedAt() {
         return createdAt;
     }
+
+    public void revoke(Instant revokedAt) {
+        this.revokedAt = revokedAt;
+    }
 }

--- a/backend/auth/src/main/java/com/vodplatform/auth/persistence/RefreshTokenRepository.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/persistence/RefreshTokenRepository.java
@@ -1,7 +1,13 @@
 package com.vodplatform.auth.persistence;
 
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity, UUID> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<RefreshTokenEntity> findByTokenHash(String tokenHash);
 }

--- a/backend/auth/src/main/java/com/vodplatform/auth/service/RefreshTokenRotationService.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/service/RefreshTokenRotationService.java
@@ -1,0 +1,62 @@
+package com.vodplatform.auth.service;
+
+import com.vodplatform.auth.dto.AuthResponse;
+import com.vodplatform.auth.dto.RefreshRequest;
+import com.vodplatform.auth.exception.InvalidRefreshTokenException;
+import com.vodplatform.auth.persistence.RefreshTokenEntity;
+import com.vodplatform.auth.persistence.RefreshTokenRepository;
+import com.vodplatform.auth.persistence.UserEntity;
+import com.vodplatform.auth.persistence.UserStatus;
+import java.time.Clock;
+import java.time.Instant;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RefreshTokenRotationService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final RefreshTokenService refreshTokenService;
+    private final JwtAccessTokenService jwtAccessTokenService;
+    private final UserProfileMapper userProfileMapper;
+    private final Clock clock;
+
+    public RefreshTokenRotationService(
+            RefreshTokenRepository refreshTokenRepository,
+            RefreshTokenService refreshTokenService,
+            JwtAccessTokenService jwtAccessTokenService,
+            UserProfileMapper userProfileMapper,
+            Clock clock
+    ) {
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.refreshTokenService = refreshTokenService;
+        this.jwtAccessTokenService = jwtAccessTokenService;
+        this.userProfileMapper = userProfileMapper;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public AuthResponse rotate(RefreshRequest request) {
+        Instant now = clock.instant();
+        String tokenHash = refreshTokenService.hash(request.refreshToken());
+        RefreshTokenEntity currentToken = refreshTokenRepository.findByTokenHash(tokenHash)
+                .orElseThrow(InvalidRefreshTokenException::new);
+        UserEntity user = currentToken.getUser();
+
+        if (currentToken.getRevokedAt() != null
+                || !currentToken.getExpiresAt().isAfter(now)
+                || user.getStatus() != UserStatus.ACTIVE) {
+            throw new InvalidRefreshTokenException();
+        }
+
+        currentToken.revoke(now);
+        IssuedAccessToken accessToken = jwtAccessTokenService.issue(user);
+        IssuedRefreshToken refreshToken = refreshTokenService.issue(user);
+        return new AuthResponse(
+                userProfileMapper.toProfile(user),
+                accessToken.value(),
+                refreshToken.value(),
+                accessToken.expiresInSeconds()
+        );
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/web/RefreshTokenController.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/web/RefreshTokenController.java
@@ -1,0 +1,27 @@
+package com.vodplatform.auth.web;
+
+import com.vodplatform.auth.dto.AuthResponse;
+import com.vodplatform.auth.dto.RefreshRequest;
+import com.vodplatform.auth.service.RefreshTokenRotationService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class RefreshTokenController {
+
+    private final RefreshTokenRotationService refreshTokenRotationService;
+
+    public RefreshTokenController(RefreshTokenRotationService refreshTokenRotationService) {
+        this.refreshTokenRotationService = refreshTokenRotationService;
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<AuthResponse> refresh(@Valid @RequestBody RefreshRequest request) {
+        return ResponseEntity.ok(refreshTokenRotationService.rotate(request));
+    }
+}

--- a/backend/auth/src/test/java/com/vodplatform/auth/service/RefreshTokenRotationServiceTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/service/RefreshTokenRotationServiceTest.java
@@ -1,0 +1,138 @@
+package com.vodplatform.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.vodplatform.auth.dto.AuthResponse;
+import com.vodplatform.auth.dto.RefreshRequest;
+import com.vodplatform.auth.dto.UserProfile;
+import com.vodplatform.auth.exception.InvalidRefreshTokenException;
+import com.vodplatform.auth.persistence.RefreshTokenEntity;
+import com.vodplatform.auth.persistence.RefreshTokenRepository;
+import com.vodplatform.auth.persistence.UserEntity;
+import com.vodplatform.auth.persistence.UserStatus;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class RefreshTokenRotationServiceTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-21T12:00:00Z");
+
+    private final RefreshTokenRepository refreshTokenRepository = mock(RefreshTokenRepository.class);
+    private final RefreshTokenService refreshTokenService = mock(RefreshTokenService.class);
+    private final JwtAccessTokenService jwtAccessTokenService = mock(JwtAccessTokenService.class);
+    private final UserProfileMapper userProfileMapper = mock(UserProfileMapper.class);
+    private final RefreshTokenRotationService service = new RefreshTokenRotationService(
+            refreshTokenRepository,
+            refreshTokenService,
+            jwtAccessTokenService,
+            userProfileMapper,
+            Clock.fixed(NOW, ZoneOffset.UTC)
+    );
+
+    @Test
+    void validTokenIsRevokedAndReplacedInOneRotationResult() {
+        UserEntity user = activeUser();
+        RefreshTokenEntity token = new RefreshTokenEntity(
+                UUID.randomUUID(),
+                user,
+                "stored-hash",
+                NOW.plusSeconds(60),
+                NOW.minusSeconds(60)
+        );
+        UserProfile profile = new UserProfile(
+                user.getId(),
+                user.getEmail(),
+                user.getDisplayName(),
+                java.util.List.of()
+        );
+        when(refreshTokenService.hash("raw-token")).thenReturn("stored-hash");
+        when(refreshTokenRepository.findByTokenHash("stored-hash")).thenReturn(Optional.of(token));
+        when(jwtAccessTokenService.issue(user)).thenReturn(new IssuedAccessToken("new-access", 900));
+        when(refreshTokenService.issue(user)).thenReturn(new IssuedRefreshToken(
+                "new-refresh",
+                "new-refresh-hash",
+                NOW.plusSeconds(604800)
+        ));
+        when(userProfileMapper.toProfile(user)).thenReturn(profile);
+
+        AuthResponse response = service.rotate(new RefreshRequest("raw-token"));
+
+        assertThat(response.user()).isEqualTo(profile);
+        assertThat(response.accessToken()).isEqualTo("new-access");
+        assertThat(response.refreshToken()).isEqualTo("new-refresh");
+        assertThat(response.expiresInSeconds()).isEqualTo(900);
+        assertThat(token.getRevokedAt()).isEqualTo(NOW);
+        verify(refreshTokenRepository).findByTokenHash("stored-hash");
+    }
+
+    @Test
+    void tokenExpiringAtCurrentInstantIsRejectedWithoutIssuingReplacementTokens() {
+        UserEntity user = activeUser();
+        RefreshTokenEntity token = new RefreshTokenEntity(
+                UUID.randomUUID(),
+                user,
+                "stored-hash",
+                NOW,
+                NOW.minusSeconds(60)
+        );
+        when(refreshTokenService.hash("raw-token")).thenReturn("stored-hash");
+        when(refreshTokenRepository.findByTokenHash("stored-hash")).thenReturn(Optional.of(token));
+
+        assertThatThrownBy(() -> service.rotate(new RefreshRequest("raw-token")))
+                .isInstanceOf(InvalidRefreshTokenException.class)
+                .hasMessage("Invalid refresh token");
+
+        assertThat(token.getRevokedAt()).isNull();
+        verify(refreshTokenService, never()).issue(any());
+        verifyNoInteractions(jwtAccessTokenService, userProfileMapper);
+    }
+
+    @Test
+    void disabledTokenOwnerIsRejectedWithoutIssuingReplacementTokens() {
+        UserEntity user = userWithStatus(UserStatus.DISABLED);
+        RefreshTokenEntity token = new RefreshTokenEntity(
+                UUID.randomUUID(),
+                user,
+                "stored-hash",
+                NOW.plusSeconds(60),
+                NOW.minusSeconds(60)
+        );
+        when(refreshTokenService.hash("raw-token")).thenReturn("stored-hash");
+        when(refreshTokenRepository.findByTokenHash("stored-hash")).thenReturn(Optional.of(token));
+
+        assertThatThrownBy(() -> service.rotate(new RefreshRequest("raw-token")))
+                .isInstanceOf(InvalidRefreshTokenException.class)
+                .hasMessage("Invalid refresh token");
+
+        assertThat(token.getRevokedAt()).isNull();
+        verify(refreshTokenService, never()).issue(any());
+        verifyNoInteractions(jwtAccessTokenService, userProfileMapper);
+    }
+
+    private UserEntity activeUser() {
+        return userWithStatus(UserStatus.ACTIVE);
+    }
+
+    private UserEntity userWithStatus(UserStatus status) {
+        return new UserEntity(
+                UUID.randomUUID(),
+                "viewer@example.com",
+                "password-hash",
+                "Viewer",
+                status,
+                NOW.minusSeconds(60),
+                NOW.minusSeconds(60)
+        );
+    }
+}

--- a/backend/common/src/test/java/com/vodplatform/common/AuthComponentScanTests.java
+++ b/backend/common/src/test/java/com/vodplatform/common/AuthComponentScanTests.java
@@ -3,8 +3,10 @@ package com.vodplatform.common;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.vodplatform.auth.service.LoginService;
+import com.vodplatform.auth.service.RefreshTokenRotationService;
 import com.vodplatform.auth.service.RegistrationService;
 import com.vodplatform.auth.web.LoginController;
+import com.vodplatform.auth.web.RefreshTokenController;
 import com.vodplatform.auth.web.RegistrationController;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,11 +30,19 @@ class AuthComponentScanTests {
     @Autowired
     private LoginController loginController;
 
+    @Autowired
+    private RefreshTokenRotationService refreshTokenRotationService;
+
+    @Autowired
+    private RefreshTokenController refreshTokenController;
+
     @Test
     void executableApplicationLoadsAuthComponentsFromRuntimeClasspath() {
         assertThat(registrationService).isNotNull();
         assertThat(registrationController).isNotNull();
         assertThat(loginService).isNotNull();
         assertThat(loginController).isNotNull();
+        assertThat(refreshTokenRotationService).isNotNull();
+        assertThat(refreshTokenController).isNotNull();
     }
 }

--- a/backend/common/src/test/java/com/vodplatform/common/RefreshTokenIntegrationTests.java
+++ b/backend/common/src/test/java/com/vodplatform/common/RefreshTokenIntegrationTests.java
@@ -18,6 +18,7 @@ import com.vodplatform.auth.service.RefreshTokenService;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,9 +66,7 @@ class RefreshTokenIntegrationTests {
 
     @BeforeEach
     void createRegisteredUser() {
-        refreshTokenRepository.deleteAll();
-        userRepository.deleteAll();
-        roleRepository.deleteAll();
+        cleanDatabase();
         jdbcTemplate.update("INSERT INTO roles (name) VALUES (?)", "ROLE_USER");
         RoleEntity role = roleRepository.findByName("ROLE_USER").orElseThrow();
         Instant now = Instant.now();
@@ -82,6 +81,13 @@ class RefreshTokenIntegrationTests {
         );
         user.addRole(role);
         userRepository.saveAndFlush(user);
+    }
+
+    @AfterEach
+    void cleanDatabase() {
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        roleRepository.deleteAll();
     }
 
     @Test

--- a/backend/common/src/test/java/com/vodplatform/common/RefreshTokenIntegrationTests.java
+++ b/backend/common/src/test/java/com/vodplatform/common/RefreshTokenIntegrationTests.java
@@ -1,0 +1,189 @@
+package com.vodplatform.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vodplatform.auth.persistence.RefreshTokenEntity;
+import com.vodplatform.auth.persistence.RefreshTokenRepository;
+import com.vodplatform.auth.persistence.RoleEntity;
+import com.vodplatform.auth.persistence.RoleRepository;
+import com.vodplatform.auth.persistence.UserEntity;
+import com.vodplatform.auth.persistence.UserRepository;
+import com.vodplatform.auth.persistence.UserStatus;
+import com.vodplatform.auth.service.RefreshTokenService;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest(
+        properties = {
+                "auth.tokens.secret=test-only-secret-with-at-least-32-bytes",
+                "auth.tokens.access-token-ttl=15m",
+                "auth.tokens.refresh-token-ttl=7d"
+        }
+)
+@AutoConfigureMockMvc
+class RefreshTokenIntegrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private RefreshTokenService refreshTokenService;
+
+    @BeforeEach
+    void createRegisteredUser() {
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        roleRepository.deleteAll();
+        jdbcTemplate.update("INSERT INTO roles (name) VALUES (?)", "ROLE_USER");
+        RoleEntity role = roleRepository.findByName("ROLE_USER").orElseThrow();
+        Instant now = Instant.now();
+        UserEntity user = new UserEntity(
+                UUID.randomUUID(),
+                "viewer@example.com",
+                passwordEncoder.encode("strong-password"),
+                "Viewer",
+                UserStatus.ACTIVE,
+                now,
+                now
+        );
+        user.addRole(role);
+        userRepository.saveAndFlush(user);
+    }
+
+    @Test
+    void validRefreshTokenRotatesAndReturnsNewTokens() throws Exception {
+        String originalRefreshToken = loginAndReadRefreshToken();
+
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(
+                                objectMapper.createObjectNode().put("refreshToken", originalRefreshToken)
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user.email").value("viewer@example.com"))
+                .andExpect(jsonPath("$.user.roles[0]").value("ROLE_USER"))
+                .andExpect(jsonPath("$.accessToken").isString())
+                .andExpect(jsonPath("$.refreshToken").isString())
+                .andExpect(jsonPath("$.expiresInSeconds").value(900))
+                .andReturn();
+
+        String rotatedRefreshToken = objectMapper.readTree(result.getResponse().getContentAsByteArray())
+                .path("refreshToken")
+                .asText();
+        assertThat(rotatedRefreshToken).isNotEqualTo(originalRefreshToken);
+
+        List<RefreshTokenEntity> storedTokens = refreshTokenRepository.findAll();
+        assertThat(storedTokens).hasSize(2);
+        RefreshTokenEntity originalStoredToken = storedTokens.stream()
+                .filter(token -> token.getTokenHash().equals(refreshTokenService.hash(originalRefreshToken)))
+                .findFirst()
+                .orElseThrow();
+        RefreshTokenEntity rotatedStoredToken = storedTokens.stream()
+                .filter(token -> token.getTokenHash().equals(refreshTokenService.hash(rotatedRefreshToken)))
+                .findFirst()
+                .orElseThrow();
+        assertThat(originalStoredToken.getRevokedAt()).isNotNull();
+        assertThat(rotatedStoredToken.getRevokedAt()).isNull();
+        assertThat(storedTokens)
+                .extracting(RefreshTokenEntity::getTokenHash)
+                .doesNotContain(originalRefreshToken, rotatedRefreshToken);
+    }
+
+    @Test
+    void replayedAndUnknownRefreshTokensReturnIndistinguishableUnauthorizedErrors() throws Exception {
+        String originalRefreshToken = loginAndReadRefreshToken();
+        byte[] requestBody = objectMapper.writeValueAsBytes(
+                objectMapper.createObjectNode().put("refreshToken", originalRefreshToken)
+        );
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk());
+
+        String replayedResponse = mockMvc.perform(post("/api/v1/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("INVALID_REFRESH_TOKEN"))
+                .andExpect(jsonPath("$.message").value("Invalid refresh token"))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        String unknownResponse = mockMvc.perform(post("/api/v1/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"refreshToken":"unknown-refresh-token"}
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode replayedError = objectMapper.readTree(replayedResponse);
+        JsonNode unknownError = objectMapper.readTree(unknownResponse);
+        assertThat(replayedError.path("status")).isEqualTo(unknownError.path("status"));
+        assertThat(replayedError.path("code")).isEqualTo(unknownError.path("code"));
+        assertThat(replayedError.path("message")).isEqualTo(unknownError.path("message"));
+    }
+
+    @Test
+    void blankRefreshTokenFailsRequestValidation() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"refreshToken":" "}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    private String loginAndReadRefreshToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "viewer@example.com",
+                                  "password": "strong-password"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsByteArray())
+                .path("refreshToken")
+                .asText();
+    }
+}


### PR DESCRIPTION
## Stack
- Base: `feature/18-auth-login-jwt` (Draft PR #30)
- Merge this PR only after #30.

## What changed
- implement public `POST /api/v1/auth/refresh` with the frozen `RefreshRequest` and `AuthResponse` schemas
- look up submitted opaque tokens by SHA-256 hash and never persist plaintext
- reject unknown, revoked, expired, boundary-expired, and disabled-owner tokens with one generic `401`
- atomically revoke the old token and issue new access/refresh tokens
- add unit, integration, validation, replay, persistence, and runtime component-scan evidence

## Why
This completes Sprint 2 Issue 2.3 and provides secure refresh-token rotation without starting logout, bearer filtering, or frontend auth work.

## Important decisions
- `PESSIMISTIC_WRITE` locks the stored token row so concurrent submissions of the same refresh token serialize; only the first valid request can rotate it.
- The service transaction contains old-token revocation and replacement-token persistence, so a downstream failure rolls back both.
- `expires_at <= now` is expired; `DISABLED` owners cannot extend sessions.
- Unknown, replayed, expired, revoked, and disabled-owner tokens share `INVALID_REFRESH_TOKEN` / `Invalid refresh token` to avoid state disclosure.
- Lazy user/role data is resolved inside the transaction; no collection fetch join is combined with PostgreSQL `FOR UPDATE`.

## Verification
- `mvn -B -ntp verify` — PASS, all 12 backend reactor modules
- auth tests: 31 passed
- common runtime/integration tests: 8 passed
- real separate-request integration flow: login → refresh → persisted revoke/new token → replay 401
- raw-token persistence guard and `expires_at == now` unit boundary — PASS
- `git diff --cached --check` — PASS before commit
- literal contract audit against BACKLOG, API-CONTRACT, SECURITY, ADR-007, and ERD — PASS
- future-scope guard: no logout endpoint, security filter, or runtime JWT decoder

## Self-review
- [x] Code is buildable and runnable with the #18 prerequisite branch.
- [x] Build/IDE artifacts (`target/`, `.idea/`, `*.iml`) are excluded.
- [x] Commit history is clean and contains one Issue 2.3 change.
- [x] Reviewed atomicity, replay concurrency, authorization/account state, hash-only persistence, lazy loading, error disclosure, module scan, migration safety, and issue scope.
- [x] Independent read-only review found no blocker; self-review still is not a substitute for the repository owners review.
- [x] PR remains Draft and unmerged.

## Residual evidence gap
H2 integration covers sequential replay and committed request transactions; PostgreSQL concurrent double-submit is protected by the row-lock design but is not stress-tested in this batch.

Closes #19