### PR TITLE
[Feature] Implement refresh token logout

### DIFF
--- a/backend/auth/src/main/java/com/vodplatform/auth/service/LogoutService.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/service/LogoutService.java
@@ -1,0 +1,42 @@
+package com.vodplatform.auth.service;
+
+import com.vodplatform.auth.dto.RefreshRequest;
+import com.vodplatform.auth.persistence.RefreshTokenEntity;
+import com.vodplatform.auth.persistence.RefreshTokenRepository;
+import java.time.Clock;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class LogoutService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final RefreshTokenService refreshTokenService;
+    private final Clock clock;
+
+    public LogoutService(
+            RefreshTokenRepository refreshTokenRepository,
+            RefreshTokenService refreshTokenService,
+            Clock clock
+    ) {
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.refreshTokenService = refreshTokenService;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public void logout(RefreshRequest request) {
+        if (request == null) {
+            return;
+        }
+
+        String tokenHash = refreshTokenService.hash(request.refreshToken());
+        refreshTokenRepository.findByTokenHash(tokenHash)
+                .filter(token -> token.getRevokedAt() == null)
+                .ifPresent(this::revoke);
+    }
+
+    private void revoke(RefreshTokenEntity token) {
+        token.revoke(clock.instant());
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/web/LogoutController.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/web/LogoutController.java
@@ -1,0 +1,29 @@
+package com.vodplatform.auth.web;
+
+import com.vodplatform.auth.dto.RefreshRequest;
+import com.vodplatform.auth.service.LogoutService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class LogoutController {
+
+    private final LogoutService logoutService;
+
+    public LogoutController(LogoutService logoutService) {
+        this.logoutService = logoutService;
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+            @Valid @RequestBody(required = false) RefreshRequest request
+    ) {
+        logoutService.logout(request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/auth/src/test/java/com/vodplatform/auth/service/LogoutServiceTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/service/LogoutServiceTest.java
@@ -1,0 +1,94 @@
+package com.vodplatform.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.vodplatform.auth.dto.RefreshRequest;
+import com.vodplatform.auth.persistence.RefreshTokenEntity;
+import com.vodplatform.auth.persistence.RefreshTokenRepository;
+import com.vodplatform.auth.persistence.UserEntity;
+import com.vodplatform.auth.persistence.UserStatus;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class LogoutServiceTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-21T12:00:00Z");
+
+    private final RefreshTokenRepository refreshTokenRepository = mock(RefreshTokenRepository.class);
+    private final RefreshTokenService refreshTokenService = mock(RefreshTokenService.class);
+    private final LogoutService service = new LogoutService(
+            refreshTokenRepository,
+            refreshTokenService,
+            Clock.fixed(NOW, ZoneOffset.UTC)
+    );
+
+    @Test
+    void knownTokenIsRevokedAtCurrentInstant() {
+        RefreshTokenEntity token = storedToken();
+        when(refreshTokenService.hash("raw-token")).thenReturn("stored-hash");
+        when(refreshTokenRepository.findByTokenHash("stored-hash")).thenReturn(Optional.of(token));
+
+        service.logout(new RefreshRequest("raw-token"));
+
+        assertThat(token.getRevokedAt()).isEqualTo(NOW);
+        verify(refreshTokenRepository).findByTokenHash("stored-hash");
+    }
+
+    @Test
+    void omittedTokenIsAnIdempotentNoOp() {
+        service.logout(null);
+
+        verifyNoInteractions(refreshTokenService, refreshTokenRepository);
+    }
+
+    @Test
+    void unknownTokenIsAnIdempotentNoOp() {
+        when(refreshTokenService.hash("unknown-token")).thenReturn("unknown-hash");
+        when(refreshTokenRepository.findByTokenHash("unknown-hash")).thenReturn(Optional.empty());
+
+        service.logout(new RefreshRequest("unknown-token"));
+
+        verify(refreshTokenRepository).findByTokenHash("unknown-hash");
+    }
+
+    @Test
+    void repeatedLogoutPreservesOriginalRevocationTimestamp() {
+        Instant originalRevocation = NOW.minusSeconds(30);
+        RefreshTokenEntity token = storedToken();
+        token.revoke(originalRevocation);
+        when(refreshTokenService.hash("raw-token")).thenReturn("stored-hash");
+        when(refreshTokenRepository.findByTokenHash("stored-hash")).thenReturn(Optional.of(token));
+
+        service.logout(new RefreshRequest("raw-token"));
+
+        assertThat(token.getRevokedAt()).isEqualTo(originalRevocation);
+    }
+
+    private RefreshTokenEntity storedToken() {
+        Instant createdAt = NOW.minusSeconds(60);
+        UserEntity user = new UserEntity(
+                UUID.randomUUID(),
+                "viewer@example.com",
+                "password-hash",
+                "Viewer",
+                UserStatus.ACTIVE,
+                createdAt,
+                createdAt
+        );
+        return new RefreshTokenEntity(
+                UUID.randomUUID(),
+                user,
+                "stored-hash",
+                NOW.plusSeconds(60),
+                createdAt
+        );
+    }
+}

--- a/backend/common/src/test/java/com/vodplatform/common/AuthComponentScanTests.java
+++ b/backend/common/src/test/java/com/vodplatform/common/AuthComponentScanTests.java
@@ -3,9 +3,11 @@ package com.vodplatform.common;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.vodplatform.auth.service.LoginService;
+import com.vodplatform.auth.service.LogoutService;
 import com.vodplatform.auth.service.RefreshTokenRotationService;
 import com.vodplatform.auth.service.RegistrationService;
 import com.vodplatform.auth.web.LoginController;
+import com.vodplatform.auth.web.LogoutController;
 import com.vodplatform.auth.web.RefreshTokenController;
 import com.vodplatform.auth.web.RegistrationController;
 import org.junit.jupiter.api.Test;
@@ -31,6 +33,12 @@ class AuthComponentScanTests {
     private LoginController loginController;
 
     @Autowired
+    private LogoutService logoutService;
+
+    @Autowired
+    private LogoutController logoutController;
+
+    @Autowired
     private RefreshTokenRotationService refreshTokenRotationService;
 
     @Autowired
@@ -42,6 +50,8 @@ class AuthComponentScanTests {
         assertThat(registrationController).isNotNull();
         assertThat(loginService).isNotNull();
         assertThat(loginController).isNotNull();
+        assertThat(logoutService).isNotNull();
+        assertThat(logoutController).isNotNull();
         assertThat(refreshTokenRotationService).isNotNull();
         assertThat(refreshTokenController).isNotNull();
     }

--- a/backend/common/src/test/java/com/vodplatform/common/LogoutIntegrationTests.java
+++ b/backend/common/src/test/java/com/vodplatform/common/LogoutIntegrationTests.java
@@ -1,0 +1,181 @@
+package com.vodplatform.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vodplatform.auth.persistence.RefreshTokenEntity;
+import com.vodplatform.auth.persistence.RefreshTokenRepository;
+import com.vodplatform.auth.persistence.RoleEntity;
+import com.vodplatform.auth.persistence.RoleRepository;
+import com.vodplatform.auth.persistence.UserEntity;
+import com.vodplatform.auth.persistence.UserRepository;
+import com.vodplatform.auth.persistence.UserStatus;
+import com.vodplatform.auth.service.RefreshTokenService;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest(
+        properties = {
+                "auth.tokens.secret=test-only-secret-with-at-least-32-bytes",
+                "auth.tokens.access-token-ttl=15m",
+                "auth.tokens.refresh-token-ttl=7d"
+        }
+)
+@AutoConfigureMockMvc
+class LogoutIntegrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private RefreshTokenService refreshTokenService;
+
+    @BeforeEach
+    void createRegisteredUser() {
+        cleanDatabase();
+        jdbcTemplate.update("INSERT INTO roles (name) VALUES (?)", "ROLE_USER");
+        RoleEntity role = roleRepository.findByName("ROLE_USER").orElseThrow();
+        Instant now = Instant.now();
+        UserEntity user = new UserEntity(
+                UUID.randomUUID(),
+                "viewer@example.com",
+                passwordEncoder.encode("strong-password"),
+                "Viewer",
+                UserStatus.ACTIVE,
+                now,
+                now
+        );
+        user.addRole(role);
+        userRepository.saveAndFlush(user);
+    }
+
+    @AfterEach
+    void cleanDatabase() {
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        roleRepository.deleteAll();
+    }
+
+    @Test
+    void submittedRefreshTokenIsRevokedAndReturnsNoContent() throws Exception {
+        String rawRefreshToken = loginAndReadRefreshToken();
+
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(
+                                objectMapper.createObjectNode().put("refreshToken", rawRefreshToken)
+                        )))
+                .andExpect(status().isNoContent())
+                .andExpect(content().string(""));
+
+        String storedHash = refreshTokenService.hash(rawRefreshToken);
+        RefreshTokenEntity storedToken = refreshTokenRepository.findAll().stream()
+                .filter(token -> token.getTokenHash().equals(storedHash))
+                .findFirst()
+                .orElseThrow();
+        assertThat(storedToken.getRevokedAt()).isNotNull();
+    }
+
+    @Test
+    void replayedUnknownAndOmittedTokensAllReturnNoContent() throws Exception {
+        String rawRefreshToken = loginAndReadRefreshToken();
+        byte[] knownTokenBody = logoutBody(rawRefreshToken);
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(knownTokenBody))
+                .andExpect(status().isNoContent());
+        Instant originalRevocation = findStoredToken(rawRefreshToken).getRevokedAt();
+
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(knownTokenBody))
+                .andExpect(status().isNoContent());
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(logoutBody("unknown-token")))
+                .andExpect(status().isNoContent());
+        mockMvc.perform(post("/api/v1/auth/logout"))
+                .andExpect(status().isNoContent());
+
+        assertThat(findStoredToken(rawRefreshToken).getRevokedAt()).isEqualTo(originalRevocation);
+    }
+
+    @Test
+    void loggedOutRefreshTokenCannotBeRotated() throws Exception {
+        String rawRefreshToken = loginAndReadRefreshToken();
+        byte[] requestBody = logoutBody(rawRefreshToken);
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("INVALID_REFRESH_TOKEN"));
+    }
+
+    private byte[] logoutBody(String refreshToken) throws Exception {
+        return objectMapper.writeValueAsBytes(
+                objectMapper.createObjectNode().put("refreshToken", refreshToken)
+        );
+    }
+
+    private RefreshTokenEntity findStoredToken(String rawRefreshToken) {
+        String storedHash = refreshTokenService.hash(rawRefreshToken);
+        return refreshTokenRepository.findAll().stream()
+                .filter(token -> token.getTokenHash().equals(storedHash))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private String loginAndReadRefreshToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "viewer@example.com",
+                                  "password": "strong-password"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsByteArray())
+                .path("refreshToken")
+                .asText();
+    }
+}


### PR DESCRIPTION
## What changed

- Add the idempotent POST /api/v1/auth/logout endpoint with an optional refresh-token request body.
- Hash submitted tokens, lock matching persistence rows, and set revoked_at only once.
- Add unit, integration, component-scan, replay, unknown-token, omitted-body, and post-logout refresh coverage.
- Preserve deterministic shared Spring test-context state with FK-safe before/after cleanup.

## Why

Issue #20 requires refresh-token revocation with 204 No Content regardless of token presence. The implementation deliberately returns the same result for absent, unknown, and already-revoked tokens so logout is idempotent and does not disclose token existence.

This is a stacked Draft PR. Review and merge PR #31 first; this PR targets feature/19-auth-refresh-token so its diff remains limited to Issue #20.

## Verification

- Full backend Maven reactor: 12/12 modules successful; auth 35 tests and common 11 tests passed.
- Reverse-order Login/Logout/Refresh integration suite: 8 tests passed.
- git diff --cached --check: passed before commit.
- Independent static review: no blocking finding.

## Self-review

- [x] The code is buildable and runnable.
- [x] Build and IDE outputs such as target, .idea, and *.iml are excluded.
- [x] Commit history is clean and meaningful.
- [x] Reviewed correctness, security, transaction locking, token disclosure, persistence behavior, module scanning, and issue scope.
- [x] No raw refresh token is persisted or logged.

Independent review is still required before merge.