### PR TITLE
[Feature] Implement JWT authentication filter

### DIFF
--- a/backend/auth/pom.xml
+++ b/backend/auth/pom.xml
@@ -31,8 +31,8 @@
             <artifactId>spring-security-crypto</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-oauth2-jose</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/backend/auth/src/main/java/com/vodplatform/auth/config/AuthTokenConfiguration.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/config/AuthTokenConfiguration.java
@@ -10,7 +10,16 @@ import javax.crypto.spec.SecretKeySpec;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 
 @Configuration(proxyBeanMethods = false)
@@ -38,5 +47,27 @@ public class AuthTokenConfiguration {
     @Bean
     JwtEncoder jwtEncoder(SecretKey jwtSecretKey) {
         return new NimbusJwtEncoder(new ImmutableSecret<SecurityContext>(jwtSecretKey));
+    }
+
+    @Bean
+    JwtDecoder jwtDecoder(SecretKey jwtSecretKey) {
+        NimbusJwtDecoder decoder = NimbusJwtDecoder.withSecretKey(jwtSecretKey)
+                .macAlgorithm(MacAlgorithm.HS256)
+                .build();
+        decoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(
+                JwtValidators.createDefault(),
+                requiredExpirationValidator()
+        ));
+        return decoder;
+    }
+
+    private OAuth2TokenValidator<Jwt> requiredExpirationValidator() {
+        return jwt -> jwt.getExpiresAt() == null
+                ? OAuth2TokenValidatorResult.failure(new OAuth2Error(
+                        "invalid_token",
+                        "Access token expiration is required",
+                        null
+                ))
+                : OAuth2TokenValidatorResult.success();
     }
 }

--- a/backend/auth/src/main/java/com/vodplatform/auth/config/SecurityConfiguration.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/config/SecurityConfiguration.java
@@ -1,0 +1,72 @@
+package com.vodplatform.auth.config;
+
+import com.vodplatform.auth.security.AccessTokenAuthenticationConverter;
+import com.vodplatform.auth.security.ApiAuthenticationEntryPoint;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+@Configuration(proxyBeanMethods = false)
+@EnableWebSecurity
+public class SecurityConfiguration {
+
+    private static final RequestMatcher PUBLIC_ENDPOINTS = new OrRequestMatcher(
+            post("/api/v1/auth/register"),
+            post("/api/v1/auth/login"),
+            post("/api/v1/auth/refresh"),
+            post("/api/v1/auth/logout"),
+            get("/api/v1/health"),
+            get("/actuator/health"),
+            get("/actuator/health/**")
+    );
+
+    @Bean
+    @Order(1)
+    SecurityFilterChain publicEndpointSecurityFilterChain(HttpSecurity http) throws Exception {
+        applyStatelessDefaults(http);
+        http.securityMatcher(PUBLIC_ENDPOINTS)
+                .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll());
+        return http.build();
+    }
+
+    @Bean
+    @Order(2)
+    SecurityFilterChain bearerSecurityFilterChain(
+            HttpSecurity http,
+            ApiAuthenticationEntryPoint authenticationEntryPoint,
+            AccessTokenAuthenticationConverter authenticationConverter
+    ) throws Exception {
+        applyStatelessDefaults(http);
+        http.authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
+                .exceptionHandling(exceptions -> exceptions.authenticationEntryPoint(authenticationEntryPoint))
+                .oauth2ResourceServer(resourceServer -> resourceServer
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .jwt(jwt -> jwt.jwtAuthenticationConverter(authenticationConverter)));
+        return http.build();
+    }
+
+    private void applyStatelessDefaults(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .requestCache(requestCache -> requestCache.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(formLogin -> formLogin.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .logout(logout -> logout.disable());
+    }
+
+    private static RequestMatcher get(String pattern) {
+        return new AntPathRequestMatcher(pattern, HttpMethod.GET.name());
+    }
+
+    private static RequestMatcher post(String pattern) {
+        return new AntPathRequestMatcher(pattern, HttpMethod.POST.name());
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/security/AccessTokenAuthenticationConverter.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/security/AccessTokenAuthenticationConverter.java
@@ -1,0 +1,65 @@
+package com.vodplatform.auth.security;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AccessTokenAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
+
+    private static final Set<String> ALLOWED_ROLES = Set.of("ROLE_USER", "ROLE_ADMIN");
+
+    @Override
+    public AbstractAuthenticationToken convert(Jwt jwt) {
+        try {
+            String subject = requiredClaim(jwt.getSubject());
+            String userIdClaim = requiredClaim(jwt.getClaimAsString("userId"));
+            UUID userId = UUID.fromString(userIdClaim);
+            if (!UUID.fromString(subject).equals(userId)) {
+                throw invalidToken();
+            }
+
+            String email = requiredClaim(jwt.getClaimAsString("email"));
+            List<String> roles = jwt.getClaimAsStringList("roles");
+            if (roles == null || roles.isEmpty() || roles.stream().anyMatch(role -> !ALLOWED_ROLES.contains(role))) {
+                throw invalidToken();
+            }
+            List<String> normalizedRoles = roles.stream()
+                    .distinct()
+                    .sorted()
+                    .toList();
+            List<SimpleGrantedAuthority> authorities = normalizedRoles.stream()
+                    .map(SimpleGrantedAuthority::new)
+                    .toList();
+            AuthenticatedUserPrincipal principal = new AuthenticatedUserPrincipal(
+                    userId,
+                    email,
+                    normalizedRoles
+            );
+
+            return UsernamePasswordAuthenticationToken.authenticated(principal, null, authorities);
+        } catch (InvalidBearerTokenException exception) {
+            throw exception;
+        } catch (RuntimeException exception) {
+            throw new InvalidBearerTokenException("Invalid access token", exception);
+        }
+    }
+
+    private String requiredClaim(String value) {
+        if (value == null || value.isBlank()) {
+            throw invalidToken();
+        }
+        return value;
+    }
+
+    private InvalidBearerTokenException invalidToken() {
+        return new InvalidBearerTokenException("Invalid access token");
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/security/ApiAuthenticationEntryPoint.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/security/ApiAuthenticationEntryPoint.java
@@ -1,0 +1,53 @@
+package com.vodplatform.auth.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vodplatform.auth.exception.ApiError;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.util.List;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApiAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private static final String ERROR_CODE = "UNAUTHORIZED";
+    private static final String ERROR_MESSAGE = "Authentication required or invalid token";
+
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    public ApiAuthenticationEntryPoint(ObjectMapper objectMapper, Clock clock) {
+        this.objectMapper = objectMapper;
+        this.clock = clock;
+    }
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authenticationException
+    ) throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setHeader(HttpHeaders.WWW_AUTHENTICATE, "Bearer");
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(
+                response.getOutputStream(),
+                new ApiError(
+                        clock.instant(),
+                        HttpStatus.UNAUTHORIZED.value(),
+                        ERROR_CODE,
+                        ERROR_MESSAGE,
+                        List.of()
+                )
+        );
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/security/AuthenticatedUserPrincipal.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/security/AuthenticatedUserPrincipal.java
@@ -1,0 +1,24 @@
+package com.vodplatform.auth.security;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+public record AuthenticatedUserPrincipal(
+        UUID userId,
+        String email,
+        List<String> roles
+) implements Principal {
+
+    public AuthenticatedUserPrincipal {
+        Objects.requireNonNull(userId, "userId must not be null");
+        Objects.requireNonNull(email, "email must not be null");
+        roles = List.copyOf(Objects.requireNonNull(roles, "roles must not be null"));
+    }
+
+    @Override
+    public String getName() {
+        return userId.toString();
+    }
+}

--- a/backend/auth/src/test/java/com/vodplatform/auth/security/AccessTokenAuthenticationConverterTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/security/AccessTokenAuthenticationConverterTest.java
@@ -1,0 +1,76 @@
+package com.vodplatform.auth.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
+
+class AccessTokenAuthenticationConverterTest {
+
+    private static final UUID USER_ID = UUID.fromString("3d21e78c-548e-47e3-9267-32ebf8bf25aa");
+
+    private final AccessTokenAuthenticationConverter converter = new AccessTokenAuthenticationConverter();
+
+    @Test
+    void exactFrozenRolesBecomeAuthoritiesAndImmutablePrincipalData() {
+        UsernamePasswordAuthenticationToken authentication =
+                (UsernamePasswordAuthenticationToken) converter.convert(jwt(
+                        USER_ID.toString(),
+                        USER_ID.toString(),
+                        "viewer@example.com",
+                        List.of("ROLE_USER", "ROLE_ADMIN")
+                ));
+
+        assertThat(authentication.isAuthenticated()).isTrue();
+        assertThat(authentication.getCredentials()).isNull();
+        assertThat(authentication.getAuthorities())
+                .extracting(GrantedAuthority::getAuthority)
+                .containsExactly("ROLE_ADMIN", "ROLE_USER");
+        assertThat(authentication.getPrincipal())
+                .isEqualTo(new AuthenticatedUserPrincipal(
+                        USER_ID,
+                        "viewer@example.com",
+                        List.of("ROLE_ADMIN", "ROLE_USER")
+                ));
+    }
+
+    @Test
+    void subjectMustMatchUserIdClaim() {
+        assertThatThrownBy(() -> converter.convert(jwt(
+                UUID.randomUUID().toString(),
+                USER_ID.toString(),
+                "viewer@example.com",
+                List.of("ROLE_USER")
+        ))).isInstanceOf(InvalidBearerTokenException.class);
+    }
+
+    @Test
+    void unknownRoleIsRejectedInsteadOfBecomingAnAuthority() {
+        assertThatThrownBy(() -> converter.convert(jwt(
+                USER_ID.toString(),
+                USER_ID.toString(),
+                "viewer@example.com",
+                List.of("ROLE_SUPERUSER")
+        ))).isInstanceOf(InvalidBearerTokenException.class);
+    }
+
+    private Jwt jwt(String subject, String userId, String email, List<String> roles) {
+        Instant now = Instant.now();
+        return Jwt.withTokenValue("signed-token-value")
+                .header("alg", "HS256")
+                .subject(subject)
+                .issuedAt(now)
+                .expiresAt(now.plusSeconds(300))
+                .claim("userId", userId)
+                .claim("email", email)
+                .claim("roles", roles)
+                .build();
+    }
+}

--- a/backend/common/src/test/java/com/vodplatform/common/JwtSecurityIntegrationTests.java
+++ b/backend/common/src/test/java/com/vodplatform/common/JwtSecurityIntegrationTests.java
@@ -1,0 +1,288 @@
+package com.vodplatform.common;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vodplatform.auth.persistence.RefreshTokenRepository;
+import com.vodplatform.auth.persistence.RoleEntity;
+import com.vodplatform.auth.persistence.RoleRepository;
+import com.vodplatform.auth.persistence.UserEntity;
+import com.vodplatform.auth.persistence.UserRepository;
+import com.vodplatform.auth.persistence.UserStatus;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootTest(
+        properties = {
+                "auth.tokens.secret=test-only-secret-with-at-least-32-bytes",
+                "auth.tokens.access-token-ttl=15m",
+                "auth.tokens.refresh-token-ttl=7d"
+        }
+)
+@AutoConfigureMockMvc
+@Import(JwtSecurityIntegrationTests.SecurityProbeController.class)
+class JwtSecurityIntegrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtEncoder jwtEncoder;
+
+    private UUID userId;
+
+    @BeforeEach
+    void createRegisteredUser() {
+        cleanDatabase();
+        jdbcTemplate.update("INSERT INTO roles (name) VALUES (?)", "ROLE_USER");
+        RoleEntity role = roleRepository.findByName("ROLE_USER").orElseThrow();
+        Instant now = Instant.now();
+        userId = UUID.randomUUID();
+        UserEntity user = new UserEntity(
+                userId,
+                "viewer@example.com",
+                passwordEncoder.encode("strong-password"),
+                "Viewer",
+                UserStatus.ACTIVE,
+                now,
+                now
+        );
+        user.addRole(role);
+        userRepository.saveAndFlush(user);
+    }
+
+    @AfterEach
+    void cleanDatabase() {
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        roleRepository.deleteAll();
+    }
+
+    @Test
+    void anonymousMalformedAndTamperedBearerTokensReturnGenericUnauthorized() throws Exception {
+        assertUnauthorized(null);
+        assertUnauthorized("Bearer not-a-jwt");
+        assertUnauthorized("Bearer " + tamperSignature(loginAndReadTokens().path("accessToken").asText()));
+    }
+
+    @Test
+    void validBearerTokenPopulatesUserAndRolesInSecurityContext() throws Exception {
+        String accessToken = loginAndReadTokens().path("accessToken").asText();
+
+        mockMvc.perform(get("/test/security-context")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.principal.userId").value(userId.toString()))
+                .andExpect(jsonPath("$.principal.email").value("viewer@example.com"))
+                .andExpect(jsonPath("$.principal.roles[0]").value("ROLE_USER"))
+                .andExpect(jsonPath("$.authorities[0]").value("ROLE_USER"));
+    }
+
+    @Test
+    void expiredBearerTokenReturnsUnauthorized() throws Exception {
+        Instant now = Instant.now();
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .subject(userId.toString())
+                .issuedAt(now.minusSeconds(600))
+                .expiresAt(now.minusSeconds(300))
+                .claim("userId", userId.toString())
+                .claim("email", "viewer@example.com")
+                .claim("roles", List.of("ROLE_USER"))
+                .build();
+        String expiredToken = jwtEncoder.encode(JwtEncoderParameters.from(
+                JwsHeader.with(MacAlgorithm.HS256).type("JWT").build(),
+                claims
+        )).getTokenValue();
+
+        assertUnauthorized("Bearer " + expiredToken);
+    }
+
+    @Test
+    void signedTokenWithoutRequiredRolesClaimReturnsUnauthorized() throws Exception {
+        Instant now = Instant.now();
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .subject(userId.toString())
+                .issuedAt(now)
+                .expiresAt(now.plusSeconds(300))
+                .claim("userId", userId.toString())
+                .claim("email", "viewer@example.com")
+                .build();
+        String incompleteToken = jwtEncoder.encode(JwtEncoderParameters.from(
+                JwsHeader.with(MacAlgorithm.HS256).type("JWT").build(),
+                claims
+        )).getTokenValue();
+
+        assertUnauthorized("Bearer " + incompleteToken);
+    }
+
+    @Test
+    void signedTokenWithoutExpirationReturnsUnauthorized() throws Exception {
+        Instant now = Instant.now();
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .subject(userId.toString())
+                .issuedAt(now)
+                .claim("userId", userId.toString())
+                .claim("email", "viewer@example.com")
+                .claim("roles", List.of("ROLE_USER"))
+                .build();
+        String nonExpiringToken = jwtEncoder.encode(JwtEncoderParameters.from(
+                JwsHeader.with(MacAlgorithm.HS256).type("JWT").build(),
+                claims
+        )).getTokenValue();
+
+        assertUnauthorized("Bearer " + nonExpiringToken);
+    }
+
+    @Test
+    void publicOperationsBypassInvalidBearerValidation() throws Exception {
+        String invalidAuthorization = "Bearer not-a-jwt";
+
+        mockMvc.perform(get("/api/v1/health")
+                        .header(HttpHeaders.AUTHORIZATION, invalidAuthorization))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .header(HttpHeaders.AUTHORIZATION, invalidAuthorization)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "new-viewer@example.com",
+                                  "password": "another-strong-password",
+                                  "displayName": "New Viewer"
+                                }
+                                """))
+                .andExpect(status().isCreated());
+
+        JsonNode login = loginAndReadTokens(invalidAuthorization);
+        JsonNode refresh = performAuthRequest(
+                "/api/v1/auth/refresh",
+                objectMapper.createObjectNode().put("refreshToken", login.path("refreshToken").asText()),
+                invalidAuthorization,
+                200
+        );
+        performAuthRequest(
+                "/api/v1/auth/logout",
+                objectMapper.createObjectNode().put("refreshToken", refresh.path("refreshToken").asText()),
+                invalidAuthorization,
+                204
+        );
+    }
+
+    private void assertUnauthorized(String authorization) throws Exception {
+        var request = get("/test/security-context");
+        if (authorization != null) {
+            request.header(HttpHeaders.AUTHORIZATION, authorization);
+        }
+        mockMvc.perform(request)
+                .andExpect(status().isUnauthorized())
+                .andExpect(header().string(HttpHeaders.WWW_AUTHENTICATE, "Bearer"))
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                .andExpect(jsonPath("$.message").value("Authentication required or invalid token"));
+    }
+
+    private JsonNode loginAndReadTokens() throws Exception {
+        return loginAndReadTokens(null);
+    }
+
+    private JsonNode loginAndReadTokens(String authorization) throws Exception {
+        return performAuthRequest(
+                "/api/v1/auth/login",
+                objectMapper.createObjectNode()
+                        .put("email", "viewer@example.com")
+                        .put("password", "strong-password"),
+                authorization,
+                200
+        );
+    }
+
+    private JsonNode performAuthRequest(
+            String path,
+            JsonNode body,
+            String authorization,
+            int expectedStatus
+    ) throws Exception {
+        var request = post(path)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(body));
+        if (authorization != null) {
+            request.header(HttpHeaders.AUTHORIZATION, authorization);
+        }
+        MvcResult result = mockMvc.perform(request)
+                .andExpect(status().is(expectedStatus))
+                .andReturn();
+        byte[] responseBody = result.getResponse().getContentAsByteArray();
+        return responseBody.length == 0 ? objectMapper.createObjectNode() : objectMapper.readTree(responseBody);
+    }
+
+    private String tamperSignature(String token) {
+        int signatureStart = token.lastIndexOf('.') + 1;
+        char firstSignatureCharacter = token.charAt(signatureStart);
+        char replacement = firstSignatureCharacter == 'A' ? 'B' : 'A';
+        return token.substring(0, signatureStart)
+                + replacement
+                + token.substring(signatureStart + 1);
+    }
+
+    @RestController
+    static class SecurityProbeController {
+
+        @GetMapping("/test/security-context")
+        SecurityContextSnapshot securityContext(Authentication authentication) {
+            List<String> authorities = authentication.getAuthorities().stream()
+                    .map(GrantedAuthority::getAuthority)
+                    .sorted()
+                    .toList();
+            return new SecurityContextSnapshot(authentication.getPrincipal(), authorities);
+        }
+    }
+
+    record SecurityContextSnapshot(Object principal, List<String> authorities) {
+    }
+}


### PR DESCRIPTION
## What changed

- Add stateless Spring OAuth2 Resource Server authentication for every protected request.
- Decode only HS256 access tokens using the existing environment-backed secret and require signature, timestamp, expiration, userId, email, and frozen role claims.
- Populate SecurityContext with an immutable principal containing user ID, email, and roles; map ROLE_USER and ROLE_ADMIN verbatim as authorities.
- Return one generic ApiError 401 response for missing, malformed, tampered, expired, or incomplete bearer tokens.
- Use a separate public security chain so malformed bearer headers are not parsed on register, login, refresh, logout, API health, or actuator health operations.
- Add unit and executable integration coverage, including shared-database cleanup before and after every integration test.

## Contract clarification

BACKLOG Issue 2.5 and SECURITY.md list register, login, and refresh as public examples. The operation-level OpenAPI contract also marks logout and /api/v1/health with security disabled, while ADR-007 and Issue 2.4 require body-based idempotent logout. This implementation follows those more-specific contracts and preserves /actuator/health for Sprint 1 runtime checks.

## Why

Issue #21 requires protected endpoints to reject anonymous or invalid tokens while preserving true JWT bypass on public operations. Two ordered chains prevent an invalid Authorization header from blocking a public request before authorization rules run.

This is a stacked Draft PR. Merge PR #32 first; this PR targets feature/20-auth-logout so the review diff remains scoped to Issue #21.

## Verification

- TDD red state captured with 4 failing security integration tests before production configuration.
- Targeted security suite: 3 converter tests and 6 integration tests passed.
- Full backend Maven reactor: 12/12 modules successful; auth 38 tests and common 17 tests passed.
- Random-order auth/common suite passed; common 16 tests before the final no-exp test was added, followed by a full green reactor with 17.
- git diff --cached --check: passed.
- Independent security review found one missing-exp issue; explicit required-exp validation and regression coverage were added, then reviewer confirmed PASS with no further finding.

## Self-review

- [x] The code is buildable and runnable.
- [x] Build and IDE outputs such as target, .idea, and *.iml are excluded.
- [x] Commit history is clean and meaningful.
- [x] Reviewed signature and expiry validation, claim parsing, role allowlisting, stateless behavior, generic error handling, public-route bypass, module classpath, test isolation, and scope.
- [x] No token, secret, password, or persistence entity is stored in SecurityContext or logged.
- [x] No Issue #22 RBAC behavior was implemented.

Independent review is still required before merge.