### PR TITLE
[Feature] Add admin role authorization

### DIFF
--- a/backend/auth/src/main/java/com/vodplatform/auth/config/SecurityConfiguration.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/config/SecurityConfiguration.java
@@ -1,11 +1,13 @@
 package com.vodplatform.auth.config;
 
 import com.vodplatform.auth.security.AccessTokenAuthenticationConverter;
+import com.vodplatform.auth.security.ApiAccessDeniedHandler;
 import com.vodplatform.auth.security.ApiAuthenticationEntryPoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -16,6 +18,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 
 @Configuration(proxyBeanMethods = false)
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfiguration {
 
     private static final RequestMatcher PUBLIC_ENDPOINTS = new OrRequestMatcher(
@@ -42,11 +45,14 @@ public class SecurityConfiguration {
     SecurityFilterChain bearerSecurityFilterChain(
             HttpSecurity http,
             ApiAuthenticationEntryPoint authenticationEntryPoint,
+            ApiAccessDeniedHandler accessDeniedHandler,
             AccessTokenAuthenticationConverter authenticationConverter
     ) throws Exception {
         applyStatelessDefaults(http);
         http.authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
-                .exceptionHandling(exceptions -> exceptions.authenticationEntryPoint(authenticationEntryPoint))
+                .exceptionHandling(exceptions -> exceptions
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler))
                 .oauth2ResourceServer(resourceServer -> resourceServer
                         .authenticationEntryPoint(authenticationEntryPoint)
                         .jwt(jwt -> jwt.jwtAuthenticationConverter(authenticationConverter)));

--- a/backend/auth/src/main/java/com/vodplatform/auth/security/ApiAccessDeniedHandler.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/security/ApiAccessDeniedHandler.java
@@ -1,0 +1,51 @@
+package com.vodplatform.auth.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vodplatform.auth.exception.ApiError;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApiAccessDeniedHandler implements AccessDeniedHandler {
+
+    private static final String ERROR_CODE = "FORBIDDEN";
+    private static final String ERROR_MESSAGE = "Authenticated user is not allowed to perform this action";
+
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    public ApiAccessDeniedHandler(ObjectMapper objectMapper, Clock clock) {
+        this.objectMapper = objectMapper;
+        this.clock = clock;
+    }
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException {
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(
+                response.getOutputStream(),
+                new ApiError(
+                        clock.instant(),
+                        HttpStatus.FORBIDDEN.value(),
+                        ERROR_CODE,
+                        ERROR_MESSAGE,
+                        List.of()
+                )
+        );
+    }
+}

--- a/backend/common/src/main/resources/db/migration/V3__seed_role_admin.sql
+++ b/backend/common/src/main/resources/db/migration/V3__seed_role_admin.sql
@@ -1,0 +1,3 @@
+INSERT INTO roles (name)
+VALUES ('ROLE_ADMIN')
+ON CONFLICT (name) DO NOTHING;

--- a/backend/common/src/test/java/com/vodplatform/common/AdminAuthorizationIntegrationTests.java
+++ b/backend/common/src/test/java/com/vodplatform/common/AdminAuthorizationIntegrationTests.java
@@ -1,0 +1,99 @@
+package com.vodplatform.common;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootTest(
+        properties = {
+                "auth.tokens.secret=test-only-secret-with-at-least-32-bytes",
+                "auth.tokens.access-token-ttl=15m",
+                "auth.tokens.refresh-token-ttl=7d"
+        }
+)
+@AutoConfigureMockMvc
+@Import(AdminAuthorizationIntegrationTests.AdminAuthorizationProbeController.class)
+class AdminAuthorizationIntegrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtEncoder jwtEncoder;
+
+    @Test
+    void roleUserReceivesForbiddenForAdminOperation() throws Exception {
+        mockMvc.perform(get("/test/admin-authorization")
+                        .header(HttpHeaders.AUTHORIZATION, bearerToken("ROLE_USER")))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+                .andExpect(jsonPath("$.message")
+                        .value("Authenticated user is not allowed to perform this action"));
+    }
+
+    @Test
+    void roleAdminCanAccessAdminOperation() throws Exception {
+        mockMvc.perform(get("/test/admin-authorization")
+                        .header(HttpHeaders.AUTHORIZATION, bearerToken("ROLE_ADMIN")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("allowed"));
+    }
+
+    @Test
+    void anonymousRequestStillReceivesUnauthorized() throws Exception {
+        mockMvc.perform(get("/test/admin-authorization"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+    }
+
+    private String bearerToken(String role) {
+        UUID userId = UUID.randomUUID();
+        Instant now = Instant.now();
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .subject(userId.toString())
+                .issuedAt(now)
+                .expiresAt(now.plusSeconds(300))
+                .claim("userId", userId.toString())
+                .claim("email", "rbac-test@example.com")
+                .claim("roles", List.of(role))
+                .build();
+        String token = jwtEncoder.encode(JwtEncoderParameters.from(
+                JwsHeader.with(MacAlgorithm.HS256).type("JWT").build(),
+                claims
+        )).getTokenValue();
+        return "Bearer " + token;
+    }
+
+    @RestController
+    static class AdminAuthorizationProbeController {
+
+        @GetMapping("/test/admin-authorization")
+        @PreAuthorize("hasRole('ADMIN')")
+        AdminAuthorizationResponse adminOnly() {
+            return new AdminAuthorizationResponse("allowed");
+        }
+    }
+
+    record AdminAuthorizationResponse(String status) {
+    }
+}


### PR DESCRIPTION
## What changed
- enabled Spring method security for backend authorization
- added a shared JSON 403 access-denied response matching the frozen API contract
- seeded the frozen ROLE_ADMIN lookup value with an idempotent Flyway migration
- added an integration probe covering anonymous, ROLE_USER, and ROLE_ADMIN behavior

## Why
Issue #22 requires the RBAC enforcement mechanism used by future admin operations. Production admin controllers belong to later sprint issues, so this batch verifies the exact annotation and authority semantics without inventing future endpoints.

## Verification
- full backend Maven reactor: 12/12 modules successful
- backend common tests: 20 passed, including 3 RBAC integration cases
- git diff --check: clean
- independent static review: PASS

## Scope limitation
This PR does not add production admin endpoints or an admin-account provisioning flow. RBAC is verified with a test-only controller; each future admin endpoint must explicitly apply @PreAuthorize("hasRole('ADMIN')"). ROLE_ADMIN is seeded, but assigning it to an operator account remains outside this issue and frozen contract.

## Self-review
- [x] Code is buildable and runnable
- [x] Build and IDE outputs remain excluded
- [x] Commit history is clean and meaningful
- [x] Reviewed correctness, security, authorization consistency, migration safety, module boundaries, and scope

Stacked on PR #33. Merge only after its prerequisite branch.