### PR TITLE
[Feature] Add current user profile endpoints

### DIFF
--- a/backend/auth/src/main/java/com/vodplatform/auth/exception/AuthExceptionHandler.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/exception/AuthExceptionHandler.java
@@ -58,6 +58,16 @@ public class AuthExceptionHandler {
         );
     }
 
+    @ExceptionHandler(CurrentUserUnavailableException.class)
+    ResponseEntity<ApiError> handleCurrentUserUnavailable(CurrentUserUnavailableException exception) {
+        return buildResponse(
+                HttpStatus.UNAUTHORIZED,
+                "UNAUTHORIZED",
+                exception.getMessage(),
+                List.of()
+        );
+    }
+
     @ExceptionHandler(HttpMessageNotReadableException.class)
     ResponseEntity<ApiError> handleUnreadableRequest() {
         return buildResponse(

--- a/backend/auth/src/main/java/com/vodplatform/auth/exception/CurrentUserUnavailableException.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/exception/CurrentUserUnavailableException.java
@@ -1,0 +1,8 @@
+package com.vodplatform.auth.exception;
+
+public class CurrentUserUnavailableException extends RuntimeException {
+
+    public CurrentUserUnavailableException() {
+        super("Authentication required or invalid token");
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/persistence/UserEntity.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/persistence/UserEntity.java
@@ -75,6 +75,11 @@ public class UserEntity {
         roles.add(role);
     }
 
+    public void updateDisplayName(String displayName, Instant updatedAt) {
+        this.displayName = displayName;
+        this.updatedAt = updatedAt;
+    }
+
     public UUID getId() {
         return id;
     }
@@ -93,6 +98,10 @@ public class UserEntity {
 
     public UserStatus getStatus() {
         return status;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
     }
 
     public Set<RoleEntity> getRoles() {

--- a/backend/auth/src/main/java/com/vodplatform/auth/persistence/UserRepository.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/persistence/UserRepository.java
@@ -9,6 +9,10 @@ public interface UserRepository extends JpaRepository<UserEntity, UUID> {
 
     boolean existsByEmail(String email);
 
+    @Override
+    @EntityGraph(attributePaths = "roles")
+    Optional<UserEntity> findById(UUID id);
+
     @EntityGraph(attributePaths = "roles")
     Optional<UserEntity> findByEmail(String email);
 }

--- a/backend/common/pom.xml
+++ b/backend/common/pom.xml
@@ -20,6 +20,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.vodplatform</groupId>
+            <artifactId>user</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>

--- a/backend/common/src/test/java/com/vodplatform/common/UserProfileIntegrationTests.java
+++ b/backend/common/src/test/java/com/vodplatform/common/UserProfileIntegrationTests.java
@@ -1,0 +1,180 @@
+package com.vodplatform.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.vodplatform.auth.persistence.RefreshTokenRepository;
+import com.vodplatform.auth.persistence.RoleEntity;
+import com.vodplatform.auth.persistence.RoleRepository;
+import com.vodplatform.auth.persistence.UserEntity;
+import com.vodplatform.auth.persistence.UserRepository;
+import com.vodplatform.auth.persistence.UserStatus;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(
+        properties = {
+                "auth.tokens.secret=test-only-secret-with-at-least-32-bytes",
+                "auth.tokens.access-token-ttl=15m",
+                "auth.tokens.refresh-token-ttl=7d"
+        }
+)
+@AutoConfigureMockMvc
+class UserProfileIntegrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private JwtEncoder jwtEncoder;
+
+    private UserEntity currentUser;
+    private UserEntity otherUser;
+    private String accessToken;
+
+    @BeforeEach
+    void createUsers() {
+        cleanDatabase();
+        jdbcTemplate.update("INSERT INTO roles (name) VALUES (?)", "ROLE_USER");
+        RoleEntity role = roleRepository.findByName("ROLE_USER").orElseThrow();
+        Instant now = Instant.now();
+        currentUser = new UserEntity(
+                UUID.randomUUID(),
+                "current@example.com",
+                "current-password-hash",
+                "Current Viewer",
+                UserStatus.ACTIVE,
+                now,
+                now
+        );
+        currentUser.addRole(role);
+        otherUser = new UserEntity(
+                UUID.randomUUID(),
+                "other@example.com",
+                "other-password-hash",
+                "Other Viewer",
+                UserStatus.ACTIVE,
+                now,
+                now
+        );
+        otherUser.addRole(role);
+        userRepository.saveAllAndFlush(List.of(currentUser, otherUser));
+        accessToken = tokenFor(currentUser);
+    }
+
+    @AfterEach
+    void cleanDatabase() {
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        roleRepository.deleteAll();
+    }
+
+    @Test
+    void getsOnlyAuthenticatedUsersProfile() throws Exception {
+        mockMvc.perform(get("/api/v1/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(currentUser.getId().toString()))
+                .andExpect(jsonPath("$.email").value("current@example.com"))
+                .andExpect(jsonPath("$.displayName").value("Current Viewer"))
+                .andExpect(jsonPath("$.roles[0]").value("ROLE_USER"))
+                .andExpect(jsonPath("$.passwordHash").doesNotExist())
+                .andExpect(jsonPath("$.status").doesNotExist());
+    }
+
+    @Test
+    void updatesOnlyAuthenticatedUsersDisplayName() throws Exception {
+        mockMvc.perform(put("/api/v1/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "displayName": "Updated Viewer",
+                                  "email": "attacker@example.com",
+                                  "password": "replacement-password",
+                                  "roles": ["ROLE_ADMIN"]
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(currentUser.getId().toString()))
+                .andExpect(jsonPath("$.email").value("current@example.com"))
+                .andExpect(jsonPath("$.displayName").value("Updated Viewer"))
+                .andExpect(jsonPath("$.roles[0]").value("ROLE_USER"));
+
+        UserEntity persistedCurrent = userRepository.findById(currentUser.getId()).orElseThrow();
+        UserEntity persistedOther = userRepository.findById(otherUser.getId()).orElseThrow();
+        assertThat(persistedCurrent.getDisplayName()).isEqualTo("Updated Viewer");
+        assertThat(persistedCurrent.getEmail()).isEqualTo("current@example.com");
+        assertThat(persistedCurrent.getPasswordHash()).isEqualTo("current-password-hash");
+        assertThat(persistedCurrent.getRoles()).extracting(RoleEntity::getName).containsExactly("ROLE_USER");
+        assertThat(persistedOther.getDisplayName()).isEqualTo("Other Viewer");
+        assertThat(persistedOther.getEmail()).isEqualTo("other@example.com");
+        assertThat(persistedOther.getPasswordHash()).isEqualTo("other-password-hash");
+    }
+
+    @Test
+    void validatesDisplayNameAndRequiresAuthentication() throws Exception {
+        mockMvc.perform(put("/api/v1/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"displayName\":\"A\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.fieldErrors[0].field").value("displayName"));
+
+        mockMvc.perform(get("/api/v1/users/me"))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(put("/api/v1/users/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"displayName\":\"Updated Viewer\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private String tokenFor(UserEntity user) {
+        Instant now = Instant.now();
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .subject(user.getId().toString())
+                .issuedAt(now)
+                .expiresAt(now.plusSeconds(300))
+                .claim("userId", user.getId().toString())
+                .claim("email", user.getEmail())
+                .claim("roles", List.of("ROLE_USER"))
+                .build();
+        return jwtEncoder.encode(JwtEncoderParameters.from(
+                JwsHeader.with(MacAlgorithm.HS256).type("JWT").build(),
+                claims
+        )).getTokenValue();
+    }
+
+}

--- a/backend/user/pom.xml
+++ b/backend/user/pom.xml
@@ -12,4 +12,29 @@
 
     <artifactId>user</artifactId>
     <name>vod-backend-user</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vodplatform</groupId>
+            <artifactId>auth</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/backend/user/src/main/java/com/vodplatform/user/dto/UpdateProfileRequest.java
+++ b/backend/user/src/main/java/com/vodplatform/user/dto/UpdateProfileRequest.java
@@ -1,0 +1,9 @@
+package com.vodplatform.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UpdateProfileRequest(
+        @NotNull @Size(min = 2, max = 100) String displayName
+) {
+}

--- a/backend/user/src/main/java/com/vodplatform/user/service/CurrentUserProfileService.java
+++ b/backend/user/src/main/java/com/vodplatform/user/service/CurrentUserProfileService.java
@@ -1,0 +1,48 @@
+package com.vodplatform.user.service;
+
+import com.vodplatform.auth.dto.UserProfile;
+import com.vodplatform.auth.exception.CurrentUserUnavailableException;
+import com.vodplatform.auth.persistence.UserEntity;
+import com.vodplatform.auth.persistence.UserRepository;
+import com.vodplatform.auth.persistence.UserStatus;
+import com.vodplatform.auth.service.UserProfileMapper;
+import java.time.Clock;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CurrentUserProfileService {
+
+    private final UserRepository userRepository;
+    private final UserProfileMapper userProfileMapper;
+    private final Clock clock;
+
+    public CurrentUserProfileService(
+            UserRepository userRepository,
+            UserProfileMapper userProfileMapper,
+            Clock clock
+    ) {
+        this.userRepository = userRepository;
+        this.userProfileMapper = userProfileMapper;
+        this.clock = clock;
+    }
+
+    @Transactional(readOnly = true)
+    public UserProfile getProfile(UUID authenticatedUserId) {
+        return userProfileMapper.toProfile(loadActiveUser(authenticatedUserId));
+    }
+
+    @Transactional
+    public UserProfile updateDisplayName(UUID authenticatedUserId, String displayName) {
+        UserEntity user = loadActiveUser(authenticatedUserId);
+        user.updateDisplayName(displayName, clock.instant());
+        return userProfileMapper.toProfile(user);
+    }
+
+    private UserEntity loadActiveUser(UUID authenticatedUserId) {
+        return userRepository.findById(authenticatedUserId)
+                .filter(user -> user.getStatus() == UserStatus.ACTIVE)
+                .orElseThrow(CurrentUserUnavailableException::new);
+    }
+}

--- a/backend/user/src/main/java/com/vodplatform/user/web/UserProfileController.java
+++ b/backend/user/src/main/java/com/vodplatform/user/web/UserProfileController.java
@@ -1,0 +1,43 @@
+package com.vodplatform.user.web;
+
+import com.vodplatform.auth.dto.UserProfile;
+import com.vodplatform.auth.security.AuthenticatedUserPrincipal;
+import com.vodplatform.user.dto.UpdateProfileRequest;
+import com.vodplatform.user.service.CurrentUserProfileService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users/me")
+public class UserProfileController {
+
+    private final CurrentUserProfileService currentUserProfileService;
+
+    public UserProfileController(CurrentUserProfileService currentUserProfileService) {
+        this.currentUserProfileService = currentUserProfileService;
+    }
+
+    @GetMapping
+    public ResponseEntity<UserProfile> getCurrentUser(
+            @AuthenticationPrincipal AuthenticatedUserPrincipal principal
+    ) {
+        return ResponseEntity.ok(currentUserProfileService.getProfile(principal.userId()));
+    }
+
+    @PutMapping
+    public ResponseEntity<UserProfile> updateCurrentUser(
+            @AuthenticationPrincipal AuthenticatedUserPrincipal principal,
+            @Valid @RequestBody UpdateProfileRequest request
+    ) {
+        return ResponseEntity.ok(currentUserProfileService.updateDisplayName(
+                principal.userId(),
+                request.displayName()
+        ));
+    }
+}

--- a/backend/user/src/test/java/com/vodplatform/user/dto/UpdateProfileRequestValidationTest.java
+++ b/backend/user/src/test/java/com/vodplatform/user/dto/UpdateProfileRequestValidationTest.java
@@ -1,0 +1,32 @@
+package com.vodplatform.user.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class UpdateProfileRequestValidationTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void createValidator() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    void acceptsDisplayNamesWithinFrozenBounds() {
+        assertThat(validator.validate(new UpdateProfileRequest("AB"))).isEmpty();
+        assertThat(validator.validate(new UpdateProfileRequest("A".repeat(100)))).isEmpty();
+    }
+
+    @Test
+    void rejectsMissingShortAndLongDisplayNames() {
+        assertThat(validator.validate(new UpdateProfileRequest(null))).isNotEmpty();
+        assertThat(validator.validate(new UpdateProfileRequest(""))).isNotEmpty();
+        assertThat(validator.validate(new UpdateProfileRequest("A"))).isNotEmpty();
+        assertThat(validator.validate(new UpdateProfileRequest("A".repeat(101)))).isNotEmpty();
+    }
+}

--- a/backend/user/src/test/java/com/vodplatform/user/service/CurrentUserProfileServiceTest.java
+++ b/backend/user/src/test/java/com/vodplatform/user/service/CurrentUserProfileServiceTest.java
@@ -1,0 +1,115 @@
+package com.vodplatform.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.vodplatform.auth.dto.UserProfile;
+import com.vodplatform.auth.exception.CurrentUserUnavailableException;
+import com.vodplatform.auth.persistence.RoleEntity;
+import com.vodplatform.auth.persistence.UserEntity;
+import com.vodplatform.auth.persistence.UserRepository;
+import com.vodplatform.auth.persistence.UserStatus;
+import com.vodplatform.auth.service.UserProfileMapper;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CurrentUserProfileServiceTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-21T12:00:00Z");
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RoleEntity role;
+
+    private CurrentUserProfileService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CurrentUserProfileService(
+                userRepository,
+                new UserProfileMapper(),
+                Clock.fixed(NOW, ZoneOffset.UTC)
+        );
+    }
+
+    @Test
+    void getsProfileForAuthenticatedUserId() {
+        UserEntity user = activeUser(UUID.randomUUID(), "viewer@example.com", "Viewer");
+        when(role.getName()).thenReturn("ROLE_USER");
+        user.addRole(role);
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+
+        UserProfile result = service.getProfile(user.getId());
+
+        assertThat(result.id()).isEqualTo(user.getId());
+        assertThat(result.email()).isEqualTo("viewer@example.com");
+        assertThat(result.displayName()).isEqualTo("Viewer");
+        assertThat(result.roles()).containsExactly("ROLE_USER");
+    }
+
+    @Test
+    void updatesOnlyDisplayNameAndTimestampForAuthenticatedUserId() {
+        UserEntity user = activeUser(UUID.randomUUID(), "viewer@example.com", "Viewer");
+        when(role.getName()).thenReturn("ROLE_USER");
+        user.addRole(role);
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+
+        UserProfile result = service.updateDisplayName(user.getId(), "Updated Viewer");
+
+        assertThat(result.displayName()).isEqualTo("Updated Viewer");
+        assertThat(user.getDisplayName()).isEqualTo("Updated Viewer");
+        assertThat(user.getUpdatedAt()).isEqualTo(NOW);
+        assertThat(user.getEmail()).isEqualTo("viewer@example.com");
+        assertThat(user.getPasswordHash()).isEqualTo("password-hash");
+        assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        verify(userRepository).findById(user.getId());
+    }
+
+    @Test
+    void rejectsMissingOrDisabledAuthenticatedUsersWithoutExposingAccountState() {
+        UUID missingId = UUID.randomUUID();
+        when(userRepository.findById(missingId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getProfile(missingId))
+                .isInstanceOf(CurrentUserUnavailableException.class);
+
+        UserEntity disabled = new UserEntity(
+                UUID.randomUUID(),
+                "disabled@example.com",
+                "password-hash",
+                "Disabled",
+                UserStatus.DISABLED,
+                NOW.minusSeconds(60),
+                NOW.minusSeconds(60)
+        );
+        when(userRepository.findById(disabled.getId())).thenReturn(Optional.of(disabled));
+
+        assertThatThrownBy(() -> service.updateDisplayName(disabled.getId(), "Still Disabled"))
+                .isInstanceOf(CurrentUserUnavailableException.class);
+    }
+
+    private UserEntity activeUser(UUID id, String email, String displayName) {
+        return new UserEntity(
+                id,
+                email,
+                "password-hash",
+                displayName,
+                UserStatus.ACTIVE,
+                NOW.minusSeconds(60),
+                NOW.minusSeconds(60)
+        );
+    }
+}


### PR DESCRIPTION
## What changed
- added authenticated GET and PUT /api/v1/users/me endpoints using the existing UserProfile response DTO
- added a narrow UpdateProfileRequest with the frozen displayName length contract
- scoped every read/update by AuthenticatedUserPrincipal.userId and loaded response roles from persistence
- added generic 401 handling for missing or disabled current accounts
- wired the user module onto the executable common runtime classpath
- added unit, validation, ownership, data-exposure, and integration tests

## Why
Issue #23 requires current-user profile retrieval and display-name updates without allowing email, password, role, or cross-user mutation. The user module owns the profile controller, service, and request DTO while reusing auth-owned identity persistence and the existing UserProfile mapper, avoiding a broad authentication-aggregate move.

## Verification
- TDD red: missing profile implementation produced 11 expected compilation failures
- auth and user unit layers: auth 38 tests, user 5 tests passed
- focused UserProfileIntegrationTests: 3 passed
- full backend Maven verify: 12/12 modules; common 23 tests passed
- randomized auth/user/common class order: passed
- git diff --check: clean
- independent static review: PASS
- exact path, DTO fields, database identifiers, and role literals matched against frozen docs

## Security and contract notes
- user ownership comes only from the verified JWT principal UUID
- unknown request properties are ignored but cannot mutate email, password, or roles; OpenAPI does not set additionalProperties false
- missing and disabled current accounts return the same generic 401
- response roles are loaded from the database, not copied from request data

## Self-review
- [x] Code is buildable and runnable
- [x] Build and IDE outputs remain excluded
- [x] Commit history is clean and meaningful
- [x] Reviewed correctness, security, ownership, query behavior, data exposure, persistence, module dependencies, and scope

Stacked on PR #34. Merge only after its prerequisite branch.