### PR TITLE
[Feature] Add frontend auth state management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,10 @@ jobs:
         working-directory: frontend
         run: npm ci
 
+      - name: Test frontend
+        working-directory: frontend
+        run: npm test
+
       - name: Build frontend
         working-directory: frontend
         run: npm run build

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,20 +8,32 @@
       "name": "vod-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@vitejs/plugin-react": "4.3.4",
+        "@tanstack/react-query": "5.101.4",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "react-router-dom": "6.30.4"
+        "react-router-dom": "6.30.6"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "7.0.1",
+        "@testing-library/react": "16.3.2",
         "@types/react": "18.3.18",
         "@types/react-dom": "18.3.5",
+        "@vitejs/plugin-react": "4.3.4",
         "autoprefixer": "10.4.20",
-        "postcss": "8.5.3",
+        "jsdom": "30.0.1",
+        "postcss": "8.5.26",
         "tailwindcss": "3.4.17",
         "typescript": "5.7.3",
-        "vite": "6.4.3"
+        "vite": "6.4.3",
+        "vitest": "4.1.11"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -36,10 +48,64 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
@@ -54,6 +120,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
       "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -63,6 +130,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -93,6 +161,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
       "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.7",
@@ -109,6 +178,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
       "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.29.7",
@@ -125,6 +195,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -134,6 +205,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
       "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.29.7",
@@ -147,6 +219,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
       "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.29.7",
@@ -164,6 +237,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
       "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -173,6 +247,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -182,6 +257,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -191,6 +267,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
       "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -200,6 +277,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
       "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.29.7",
@@ -213,6 +291,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -228,6 +307,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
       "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -243,6 +323,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
       "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -254,10 +335,21 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
       "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -272,6 +364,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
       "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -290,6 +383,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -299,6 +393,159 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
@@ -306,6 +553,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -322,6 +570,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -338,6 +587,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -354,6 +604,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -370,6 +621,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -386,6 +638,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -402,6 +655,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -418,6 +672,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -434,6 +689,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -450,6 +706,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -466,6 +723,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -482,6 +740,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -498,6 +757,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -514,6 +774,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -530,6 +791,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -546,6 +808,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -562,6 +825,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -578,6 +842,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -594,6 +859,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -610,6 +876,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -626,6 +893,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -642,6 +910,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -658,6 +927,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -674,6 +944,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -690,6 +961,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -706,6 +978,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -715,10 +988,29 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -729,6 +1021,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -739,6 +1032,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -748,12 +1042,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -799,9 +1095,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+      "version": "1.23.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.4.tgz",
+      "integrity": "sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -814,6 +1110,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -827,6 +1124,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -840,6 +1138,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -853,6 +1152,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -866,6 +1166,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -879,6 +1180,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -892,6 +1194,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -908,6 +1211,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -924,6 +1228,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -940,6 +1245,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -956,6 +1262,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -972,6 +1279,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -988,6 +1296,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1004,6 +1313,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1020,6 +1330,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1036,6 +1347,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1052,6 +1364,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1068,6 +1381,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1084,6 +1398,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1100,6 +1415,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1113,6 +1429,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1126,6 +1443,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1139,6 +1457,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1152,6 +1471,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1165,16 +1485,144 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
+      "integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
+      "integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -1188,6 +1636,7 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
@@ -1197,6 +1646,7 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -1207,15 +1657,35 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
@@ -1250,6 +1720,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.4.tgz",
       "integrity": "sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.0",
@@ -1263,6 +1734,144 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/any-promise": {
@@ -1292,6 +1901,26 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
@@ -1335,12 +1964,23 @@
       "version": "2.10.42",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
       "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -1373,6 +2013,7 @@
       "version": "4.28.5",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
       "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -1416,6 +2057,7 @@
       "version": "1.0.30001803",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
       "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -1431,6 +2073,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -1484,6 +2136,28 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cssesc": {
@@ -1506,10 +2180,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1521,6 +2225,23 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/didyoumean": {
@@ -1537,11 +2258,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.389",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
       "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
@@ -1553,10 +2296,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1598,9 +2349,30 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-glob": {
@@ -1674,6 +2446,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1698,6 +2471,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1727,6 +2501,29 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-binary-path": {
@@ -1791,11 +2588,18 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -1807,10 +2611,62 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -1823,6 +2679,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -1867,10 +2724,39 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -1896,10 +2782,21 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -1915,9 +2812,10 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1936,6 +2834,7 @@
       "version": "2.0.50",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
       "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1981,6 +2880,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -1988,10 +2914,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -2028,9 +2962,10 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2047,7 +2982,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2182,6 +3117,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2228,22 +3189,31 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.6.tgz",
+      "integrity": "sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "@remix-run/router": "1.23.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2253,13 +3223,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.6.tgz",
+      "integrity": "sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "@remix-run/router": "1.23.4",
+        "react-router": "6.30.6"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2290,6 +3260,30 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -2329,6 +3323,7 @@
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.9"
@@ -2393,6 +3388,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -2406,18 +3414,54 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/sucrase": {
@@ -2455,6 +3499,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
@@ -2517,10 +3568,28 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -2537,6 +3606,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -2554,6 +3624,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2561,6 +3632,36 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -2573,6 +3674,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -2596,10 +3723,21 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2637,6 +3775,7 @@
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -2711,6 +3850,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -2728,6 +3868,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2736,17 +3877,203 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,21 +6,27 @@
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 5173",
     "build": "tsc -b && vite build",
-    "preview": "vite preview --host 0.0.0.0 --port 4173"
+    "preview": "vite preview --host 0.0.0.0 --port 4173",
+    "test": "vitest run"
   },
   "dependencies": {
-    "@vitejs/plugin-react": "4.3.4",
+    "@tanstack/react-query": "5.101.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-router-dom": "6.30.4"
+    "react-router-dom": "6.30.6"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "7.0.1",
+    "@testing-library/react": "16.3.2",
     "@types/react": "18.3.18",
     "@types/react-dom": "18.3.5",
+    "@vitejs/plugin-react": "4.3.4",
     "autoprefixer": "10.4.20",
-    "postcss": "8.5.3",
+    "jsdom": "30.0.1",
+    "postcss": "8.5.26",
     "tailwindcss": "3.4.17",
     "typescript": "5.7.3",
-    "vite": "6.4.3"
+    "vite": "6.4.3",
+    "vitest": "4.1.11"
   }
 }

--- a/frontend/src/app/AppProviders.tsx
+++ b/frontend/src/app/AppProviders.tsx
@@ -1,0 +1,20 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { PropsWithChildren } from 'react';
+import { AuthProvider } from '../features/auth/AuthContext';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      refetchOnWindowFocus: false
+    }
+  }
+});
+
+export function AppProviders({ children }: PropsWithChildren) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>{children}</AuthProvider>
+    </QueryClientProvider>
+  );
+}

--- a/frontend/src/features/auth/AuthContext.test.tsx
+++ b/frontend/src/features/auth/AuthContext.test.tsx
@@ -1,0 +1,854 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { StrictMode, type PropsWithChildren } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthProvider, useApiClient, useAuth } from './AuthContext';
+import {
+  AUTH_SESSION_STORAGE_KEY,
+  advanceAuthGeneration,
+  clearAuthSession,
+  createAuthSession,
+  writeAuthSession
+} from './authStorage';
+import type { AuthResponse, UserProfile } from '../../lib/api/types';
+import { AuthenticationSupersededError } from '../../lib/api/client';
+
+const user: UserProfile = {
+  id: '3fcf25c2-f096-4462-ae63-4ba4702a9078',
+  email: 'viewer@example.com',
+  displayName: 'Viewer',
+  roles: ['ROLE_USER']
+};
+
+const authResponse: AuthResponse = {
+  user,
+  accessToken: 'access-token',
+  refreshToken: 'refresh-token',
+  expiresInSeconds: 900
+};
+
+describe('AuthProvider', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    Object.defineProperty(navigator, 'locks', {
+      configurable: true,
+      value: undefined
+    });
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('logs in and persists the complete token session', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(authResponse));
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isInitializing).toBe(false));
+
+    await act(async () => {
+      await result.current.login({
+        email: 'viewer@example.com',
+        password: 'strong-password'
+      });
+    });
+
+    expect(result.current.user).toEqual(user);
+    expect(result.current.accessToken).toBe('access-token');
+    expect(result.current.refreshToken).toBe('refresh-token');
+    expect(window.localStorage.length).toBe(1);
+  });
+
+  it('exposes loading state while an auth request is pending', async () => {
+    let resolveLogin: ((response: Response) => void) | undefined;
+    fetchMock.mockReturnValue(new Promise<Response>((resolve) => {
+      resolveLogin = resolve;
+    }));
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isInitializing).toBe(false));
+
+    let loginPromise: Promise<UserProfile> = Promise.resolve(user);
+    act(() => {
+      loginPromise = result.current.login({
+        email: 'viewer@example.com',
+        password: 'strong-password'
+      });
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+    await act(async () => {
+      resolveLogin?.(jsonResponse(authResponse));
+      await loginPromise;
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.user).toEqual(user);
+  });
+
+  it('registers without creating an authenticated session', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(user, 201));
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isInitializing).toBe(false));
+
+    let registered: UserProfile | undefined;
+    await act(async () => {
+      registered = await result.current.register({
+        email: 'viewer@example.com',
+        password: 'strong-password',
+        displayName: 'Viewer'
+      });
+    });
+
+    expect(registered).toEqual(user);
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toBeNull();
+  });
+
+  it('clears local state and query cache even when logout transport fails', async () => {
+    writeAuthSession(createAuthSession(authResponse), window.localStorage);
+    fetchMock.mockRejectedValue(new TypeError('network unavailable'));
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(['private'], { secret: true });
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: createWrapper({ queryClient })
+    });
+    await waitFor(() => expect(result.current.isInitializing).toBe(false));
+
+    await act(async () => {
+      await expect(result.current.logout()).rejects.toThrow('network unavailable');
+    });
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toBeNull();
+    expect(queryClient.getQueryData(['private'])).toBeUndefined();
+  });
+
+  it('clears local state before a pending logout request settles', async () => {
+    writeAuthSession(createAuthSession(authResponse), window.localStorage);
+    let resolveLogout: ((response: Response) => void) | undefined;
+    fetchMock.mockReturnValue(new Promise<Response>((resolve) => {
+      resolveLogout = resolve;
+    }));
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isInitializing).toBe(false));
+
+    let logoutPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      logoutPromise = result.current.logout();
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toBeNull();
+    await act(async () => {
+      resolveLogout?.(new Response(null, { status: 204 }));
+      await logoutPromise;
+    });
+  });
+
+  it('bounds a stalled refresh and releases loading state', async () => {
+    writeAuthSession(createAuthSession(authResponse), window.localStorage);
+    fetchMock.mockImplementation((_input, init) => new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => {
+        reject(new DOMException('The operation was aborted', 'AbortError'));
+      });
+    }));
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isInitializing).toBe(false));
+    vi.useFakeTimers();
+
+    await act(async () => {
+      const refreshPromise = result.current.refreshTokens();
+      const refreshFailure = refreshPromise.catch((failure: unknown) => failure);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await expect(refreshFailure).resolves.toMatchObject({ name: 'AbortError' });
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it('keeps multi-token logout revocation bounded after an early failure', async () => {
+    writeAuthSession(createAuthSession(authResponse), window.localStorage);
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isInitializing).toBe(false));
+    writeAuthSession(createAuthSession({
+      ...authResponse,
+      accessToken: 'external-access-token',
+      refreshToken: 'external-refresh-token'
+    }), window.localStorage);
+    const abortedRevocation = vi.fn();
+    fetchMock.mockImplementation((_input, init) => {
+      const refreshToken = JSON.parse(init?.body?.toString() ?? '{}').refreshToken;
+      if (refreshToken === 'external-refresh-token') {
+        return Promise.reject(new TypeError('revocation unavailable'));
+      }
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          abortedRevocation();
+          reject(new DOMException('The operation was aborted', 'AbortError'));
+        });
+      });
+    });
+    vi.useFakeTimers();
+
+    let logoutPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      logoutPromise = result.current.logout();
+    });
+    const logoutFailure = logoutPromise.catch((failure: unknown) => failure);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+      await logoutFailure;
+    });
+
+    await expect(logoutFailure).resolves.toBeInstanceOf(DOMException);
+    expect(abortedRevocation).toHaveBeenCalledTimes(1);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toBeNull();
+  });
+
+  it('single-flights StrictMode bootstrap refresh for a near-expiry session', async () => {
+    const nearExpiry = {
+      ...createAuthSession(authResponse),
+      accessTokenExpiresAt: Date.now() + 1_000
+    };
+    writeAuthSession(nearExpiry, window.localStorage);
+    fetchMock.mockResolvedValue(jsonResponse({
+      ...authResponse,
+      accessToken: 'rotated-access-token',
+      refreshToken: 'rotated-refresh-token'
+    }));
+    const redirectToLogin = vi.fn();
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: createWrapper({ redirectToLogin, strict: true })
+    });
+
+    await waitFor(() => expect(result.current.isInitializing).toBe(false));
+    expect(result.current.accessToken).toBe('rotated-access-token');
+    expect(result.current.refreshToken).toBe('rotated-refresh-token');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(redirectToLogin).not.toHaveBeenCalled();
+  });
+
+  it('fails closed and redirects once when bootstrap refresh fails', async () => {
+    const nearExpiry = {
+      ...createAuthSession(authResponse),
+      accessTokenExpiresAt: Date.now() + 1_000
+    };
+    writeAuthSession(nearExpiry, window.localStorage);
+    fetchMock.mockResolvedValue(jsonResponse({ code: 'INVALID_REFRESH_TOKEN' }, 401));
+    const redirectToLogin = vi.fn();
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: createWrapper({ redirectToLogin, strict: true })
+    });
+
+    await waitFor(() => expect(result.current.isInitializing).toBe(false));
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.error).not.toBeNull();
+    expect(window.localStorage.length).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(redirectToLogin).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears logout state immediately and revokes both racing refresh tokens', async () => {
+    writeAuthSession(createAuthSession(authResponse), window.localStorage);
+    let resolveRefresh: ((response: Response) => void) | undefined;
+    const revokedRefreshTokens: string[] = [];
+    const refreshResponse = new Promise<Response>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.endsWith('/auth/refresh')) {
+        return refreshResponse;
+      }
+      revokedRefreshTokens.push(JSON.parse(init?.body?.toString() ?? '{}').refreshToken);
+      return Promise.resolve(new Response(null, { status: 204 }));
+    });
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isInitializing).toBe(false));
+
+    let refreshPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      refreshPromise = result.current.refreshTokens();
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    let logoutPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      logoutPromise = result.current.logout();
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toBeNull();
+    await act(async () => {
+      resolveRefresh?.(jsonResponse({
+        ...authResponse,
+        accessToken: 'rotated-access-token',
+        refreshToken: 'rotated-refresh-token'
+      }));
+      await expect(refreshPromise).rejects.toBeInstanceOf(AuthenticationSupersededError);
+      await logoutPromise;
+    });
+
+    expect(revokedRefreshTokens).toEqual(['refresh-token', 'rotated-refresh-token']);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toBeNull();
+  });
+
+  it('does not let a stale refresh failure clear a newer login session', async () => {
+    writeAuthSession(createAuthSession(authResponse), window.localStorage);
+    let resolveRefresh: ((response: Response) => void) | undefined;
+    const refreshResponse = new Promise<Response>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const nextUser: UserProfile = {
+      ...user,
+      id: '5189c865-94aa-41a8-96e5-d9a398647761',
+      email: 'next@example.com'
+    };
+    const nextAuthResponse: AuthResponse = {
+      user: nextUser,
+      accessToken: 'next-access-token',
+      refreshToken: 'next-refresh-token',
+      expiresInSeconds: 900
+    };
+    fetchMock.mockImplementation((input) => String(input).endsWith('/auth/refresh')
+      ? refreshResponse
+      : Promise.resolve(jsonResponse(nextAuthResponse)));
+    const redirectToLogin = vi.fn();
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: createWrapper({ redirectToLogin })
+    });
+    await waitFor(() => expect(result.current.isInitializing).toBe(false));
+
+    let refreshPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      refreshPromise = result.current.refreshTokens();
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      await result.current.login({
+        email: 'next@example.com',
+        password: 'strong-password'
+      });
+    });
+    expect(result.current.isLoading).toBe(true);
+    await act(async () => {
+      resolveRefresh?.(jsonResponse({ code: 'INVALID_REFRESH_TOKEN' }, 401));
+      await refreshPromise;
+    });
+
+    expect(result.current.user).toEqual(nextUser);
+    expect(result.current.refreshToken).toBe('next-refresh-token');
+    expect(result.current.isLoading).toBe(false);
+    expect(redirectToLogin).not.toHaveBeenCalled();
+  });
+
+  it('revokes a stale successful refresh without replacing a newer login session', async () => {
+    writeAuthSession(createAuthSession(authResponse), window.localStorage);
+    let resolveRefresh: ((response: Response) => void) | undefined;
+    let revokedRefreshToken: string | undefined;
+    const refreshResponse = new Promise<Response>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const nextUser: UserProfile = {
+      ...user,
+      id: '5189c865-94aa-41a8-96e5-d9a398647761',
+      email: 'next@example.com'
+    };
+    const nextAuthResponse: AuthResponse = {
+      user: nextUser,
+      accessToken: 'next-access-token',
+      refreshToken: 'next-refresh-token',
+      expiresInSeconds: 900
+    };
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.endsWith('/auth/refresh')) {
+        return refreshResponse;
+      }
+      if (url.endsWith('/auth/logout')) {
+        revokedRefreshToken = JSON.parse(init?.body?.toString() ?? '{}').refreshToken;
+        return Promise.resolve(new Response(null, { status: 204 }));
+      }
+      return Promise.resolve(jsonResponse(nextAuthResponse));
+    });
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isInitializing).toBe(false));
+
+    let refreshPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      refreshPromise = result.current.refreshTokens();
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      await result.current.login({
+        email: 'next@example.com',
+        password: 'strong-password'
+      });
+    });
+    await act(async () => {
+      resolveRefresh?.(jsonResponse({
+        ...authResponse,
+        accessToken: 'stale-rotated-access-token',
+        refreshToken: 'stale-rotated-refresh-token'
+      }));
+      await refreshPromise;
+    });
+
+    expect(revokedRefreshToken).toBe('stale-rotated-refresh-token');
+    expect(result.current.user).toEqual(nextUser);
+    expect(result.current.refreshToken).toBe('next-refresh-token');
+  });
+
+  it('revokes a rotated token when another tab logs out during refresh', async () => {
+    writeAuthSession(createAuthSession(authResponse), window.localStorage);
+    let resolveRefresh: ((response: Response) => void) | undefined;
+    let revokedRefreshToken: string | undefined;
+    const refreshResponse = new Promise<Response>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.endsWith('/auth/refresh')) {
+        return refreshResponse;
+      }
+      revokedRefreshToken = JSON.parse(init?.body?.toString() ?? '{}').refreshToken;
+      return Promise.resolve(new Response(null, { status: 204 }));
+    });
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isInitializing).toBe(false));
+
+    let refreshPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      refreshPromise = result.current.refreshTokens();
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    window.localStorage.removeItem(AUTH_SESSION_STORAGE_KEY);
+    await act(async () => {
+      resolveRefresh?.(jsonResponse({
+        ...authResponse,
+        accessToken: 'rotated-access-token',
+        refreshToken: 'rotated-refresh-token'
+      }));
+      await expect(refreshPromise).rejects.toBeInstanceOf(AuthenticationSupersededError);
+    });
+
+    expect(revokedRefreshToken).toBe('rotated-refresh-token');
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(window.localStorage.length).toBe(0);
+  });
+
+  it('does not overwrite another provider login with a stale refresh result', async () => {
+    writeAuthSession(createAuthSession(authResponse), window.localStorage);
+    let resolveRefresh: ((response: Response) => void) | undefined;
+    let revokedRefreshToken: string | undefined;
+    const refreshResponse = new Promise<Response>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const nextUser: UserProfile = {
+      ...user,
+      id: '5189c865-94aa-41a8-96e5-d9a398647761',
+      email: 'next@example.com'
+    };
+    const nextAuthResponse: AuthResponse = {
+      user: nextUser,
+      accessToken: 'next-access-token',
+      refreshToken: 'next-refresh-token',
+      expiresInSeconds: 900
+    };
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.endsWith('/auth/refresh')) {
+        return refreshResponse;
+      }
+      if (url.endsWith('/auth/logout')) {
+        revokedRefreshToken = JSON.parse(init?.body?.toString() ?? '{}').refreshToken;
+        return Promise.resolve(new Response(null, { status: 204 }));
+      }
+      return Promise.resolve(jsonResponse(nextAuthResponse));
+    });
+    const first = renderHook(() => useAuth(), { wrapper: createWrapper() });
+    const second = renderHook(() => useAuth(), { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(first.result.current.isInitializing).toBe(false);
+      expect(second.result.current.isInitializing).toBe(false);
+    });
+
+    let refreshPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      refreshPromise = first.result.current.refreshTokens();
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      await second.result.current.login({
+        email: 'next@example.com',
+        password: 'strong-password'
+      });
+    });
+    await act(async () => {
+      resolveRefresh?.(jsonResponse({
+        ...authResponse,
+        accessToken: 'stale-rotated-access-token',
+        refreshToken: 'stale-rotated-refresh-token'
+      }));
+      await refreshPromise;
+    });
+
+    expect(revokedRefreshToken).toBe('stale-rotated-refresh-token');
+    expect(first.result.current.user).toEqual(nextUser);
+    expect(second.result.current.user).toEqual(nextUser);
+    expect(window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toContain('next-refresh-token');
+  });
+
+  it('rejects a delayed protected response when persisted logout precedes its storage event', async () => {
+    writeAuthSession(createAuthSession(authResponse), window.localStorage);
+    let resolveResponse: ((response: Response) => void) | undefined;
+    fetchMock.mockReturnValue(new Promise<Response>((resolve) => {
+      resolveResponse = resolve;
+    }));
+    const { result } = renderHook(() => ({
+      auth: useAuth(),
+      client: useApiClient()
+    }), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.auth.isInitializing).toBe(false));
+
+    const request = result.current.client.request('/users/me', { authenticated: true });
+    const requestFailure = request.catch((failure: unknown) => failure);
+    advanceAuthGeneration(window.localStorage);
+    clearAuthSession(window.localStorage);
+    await act(async () => {
+      resolveResponse?.(jsonResponse(user));
+      await requestFailure;
+    });
+
+    await expect(requestFailure).resolves.toBeInstanceOf(AuthenticationSupersededError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('coordinates refresh and logout across providers without losing a rotated token', async () => {
+    const requestLock = installSequentialWebLocks();
+    writeAuthSession(createAuthSession(authResponse), window.localStorage);
+    let resolveRefresh: ((response: Response) => void) | undefined;
+    const revokedRefreshTokens: string[] = [];
+    const refreshResponse = new Promise<Response>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    fetchMock.mockImplementation((input, init) => {
+      if (String(input).endsWith('/auth/refresh')) {
+        return refreshResponse;
+      }
+      revokedRefreshTokens.push(JSON.parse(init?.body?.toString() ?? '{}').refreshToken);
+      return Promise.resolve(new Response(null, { status: 204 }));
+    });
+    const first = renderHook(() => useAuth(), { wrapper: createWrapper() });
+    const second = renderHook(() => useAuth(), { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(first.result.current.isInitializing).toBe(false);
+      expect(second.result.current.isInitializing).toBe(false);
+    });
+
+    let refreshPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      refreshPromise = first.result.current.refreshTokens();
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    let logoutPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      logoutPromise = second.result.current.logout();
+    });
+    expect(second.result.current.isAuthenticated).toBe(false);
+    await act(async () => {
+      resolveRefresh?.(jsonResponse({
+        ...authResponse,
+        accessToken: 'rotated-access-token',
+        refreshToken: 'rotated-refresh-token'
+      }));
+      await expect(refreshPromise).rejects.toBeInstanceOf(AuthenticationSupersededError);
+      await logoutPromise;
+    });
+
+    expect(requestLock).toHaveBeenCalledTimes(2);
+    expect(revokedRefreshTokens).toEqual(['rotated-refresh-token', 'refresh-token']);
+    expect(first.result.current.isAuthenticated).toBe(false);
+    expect(second.result.current.isAuthenticated).toBe(false);
+    expect(window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toBeNull();
+  });
+
+  it('rejects a login that began before another provider logged out', async () => {
+    writeAuthSession(createAuthSession(authResponse), window.localStorage);
+    let resolveLogin: ((response: Response) => void) | undefined;
+    const revokedRefreshTokens: string[] = [];
+    const loginResponse = new Promise<Response>((resolve) => {
+      resolveLogin = resolve;
+    });
+    const nextUser: UserProfile = {
+      ...user,
+      id: '5189c865-94aa-41a8-96e5-d9a398647761',
+      email: 'next@example.com'
+    };
+    const nextAuthResponse: AuthResponse = {
+      user: nextUser,
+      accessToken: 'next-access-token',
+      refreshToken: 'next-refresh-token',
+      expiresInSeconds: 900
+    };
+    fetchMock.mockImplementation((input, init) => {
+      if (String(input).endsWith('/auth/login')) {
+        return loginResponse;
+      }
+      revokedRefreshTokens.push(JSON.parse(init?.body?.toString() ?? '{}').refreshToken);
+      return Promise.resolve(new Response(null, { status: 204 }));
+    });
+    const first = renderHook(() => useAuth(), { wrapper: createWrapper() });
+    const second = renderHook(() => useAuth(), { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(first.result.current.isInitializing).toBe(false);
+      expect(second.result.current.isInitializing).toBe(false);
+    });
+
+    let loginPromise: Promise<UserProfile> = Promise.resolve(user);
+    act(() => {
+      loginPromise = first.result.current.login({
+        email: 'next@example.com',
+        password: 'strong-password'
+      });
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      await second.result.current.logout();
+    });
+    await act(async () => {
+      resolveLogin?.(jsonResponse(nextAuthResponse));
+      await expect(loginPromise).rejects.toBeInstanceOf(AuthenticationSupersededError);
+    });
+
+    expect(revokedRefreshTokens).toEqual(['refresh-token', 'next-refresh-token']);
+    expect(first.result.current.isAuthenticated).toBe(false);
+    expect(second.result.current.isAuthenticated).toBe(false);
+    expect(window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toBeNull();
+  });
+
+  it('revokes a superseded login response and keeps the latest login session', async () => {
+    let resolveFirstLogin: ((response: Response) => void) | undefined;
+    let revokedRefreshToken: string | undefined;
+    const firstLoginResponse = new Promise<Response>((resolve) => {
+      resolveFirstLogin = resolve;
+    });
+    const nextUser: UserProfile = {
+      ...user,
+      id: '5189c865-94aa-41a8-96e5-d9a398647761',
+      email: 'next@example.com'
+    };
+    const nextAuthResponse: AuthResponse = {
+      user: nextUser,
+      accessToken: 'next-access-token',
+      refreshToken: 'next-refresh-token',
+      expiresInSeconds: 900
+    };
+    let loginCalls = 0;
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.endsWith('/auth/logout')) {
+        revokedRefreshToken = JSON.parse(init?.body?.toString() ?? '{}').refreshToken;
+        return Promise.resolve(new Response(null, { status: 204 }));
+      }
+      loginCalls += 1;
+      return loginCalls === 1
+        ? firstLoginResponse
+        : Promise.resolve(jsonResponse(nextAuthResponse));
+    });
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isInitializing).toBe(false));
+
+    let firstLoginPromise: Promise<UserProfile> = Promise.resolve(user);
+    act(() => {
+      firstLoginPromise = result.current.login({
+        email: 'viewer@example.com',
+        password: 'strong-password'
+      });
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      await result.current.login({
+        email: 'next@example.com',
+        password: 'strong-password'
+      });
+    });
+    await act(async () => {
+      resolveFirstLogin?.(jsonResponse(authResponse));
+      await expect(firstLoginPromise).rejects.toBeInstanceOf(AuthenticationSupersededError);
+    });
+
+    expect(revokedRefreshToken).toBe('refresh-token');
+    expect(result.current.user).toEqual(nextUser);
+    expect(result.current.refreshToken).toBe('next-refresh-token');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('clears private query cache whenever the authenticated user changes', async () => {
+    writeAuthSession(createAuthSession(authResponse), window.localStorage);
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(['private'], { owner: user.id });
+    const nextUser: UserProfile = {
+      ...user,
+      id: '5189c865-94aa-41a8-96e5-d9a398647761',
+      email: 'next@example.com'
+    };
+    const nextAuthResponse: AuthResponse = {
+      user: nextUser,
+      accessToken: 'next-access-token',
+      refreshToken: 'next-refresh-token',
+      expiresInSeconds: 900
+    };
+    fetchMock.mockResolvedValue(jsonResponse(nextAuthResponse));
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: createWrapper({ queryClient })
+    });
+    await waitFor(() => expect(result.current.isInitializing).toBe(false));
+
+    await act(async () => {
+      await result.current.login({
+        email: 'next@example.com',
+        password: 'strong-password'
+      });
+    });
+    expect(queryClient.getQueryData(['private'])).toBeUndefined();
+
+    queryClient.setQueryData(['private'], { owner: nextUser.id });
+    writeAuthSession(createAuthSession(authResponse), window.localStorage);
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: AUTH_SESSION_STORAGE_KEY,
+        storageArea: window.localStorage
+      }));
+    });
+    await waitFor(() => expect(result.current.user).toEqual(user));
+    expect(queryClient.getQueryData(['private'])).toBeUndefined();
+  });
+
+  it('serializes refresh across providers with a same-origin Web Lock', async () => {
+    writeAuthSession(createAuthSession(authResponse), window.localStorage);
+    const requestLock = installSequentialWebLocks();
+    fetchMock.mockResolvedValue(jsonResponse({
+      ...authResponse,
+      accessToken: 'rotated-access-token',
+      refreshToken: 'rotated-refresh-token'
+    }));
+    const first = renderHook(() => useAuth(), { wrapper: createWrapper() });
+    const second = renderHook(() => useAuth(), { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(first.result.current.isInitializing).toBe(false);
+      expect(second.result.current.isInitializing).toBe(false);
+    });
+
+    await act(async () => {
+      await Promise.all([
+        first.result.current.refreshTokens(),
+        second.result.current.refreshTokens()
+      ]);
+    });
+
+    expect(requestLock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(first.result.current.refreshToken).toBe('rotated-refresh-token');
+    expect(second.result.current.refreshToken).toBe('rotated-refresh-token');
+  });
+
+  it('adopts a refresh session rotated by another tab instead of clearing it', async () => {
+    writeAuthSession(createAuthSession(authResponse), window.localStorage);
+    let resolveRefresh: ((response: Response) => void) | undefined;
+    fetchMock.mockReturnValue(new Promise<Response>((resolve) => {
+      resolveRefresh = resolve;
+    }));
+    const redirectToLogin = vi.fn();
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: createWrapper({ redirectToLogin })
+    });
+    await waitFor(() => expect(result.current.isInitializing).toBe(false));
+
+    let refreshPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      refreshPromise = result.current.refreshTokens();
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const otherTabResponse: AuthResponse = {
+      ...authResponse,
+      accessToken: 'other-tab-access-token',
+      refreshToken: 'other-tab-refresh-token'
+    };
+    writeAuthSession(createAuthSession(otherTabResponse), window.localStorage);
+    await act(async () => {
+      resolveRefresh?.(jsonResponse({ code: 'INVALID_REFRESH_TOKEN' }, 401));
+      await refreshPromise;
+    });
+
+    expect(result.current.accessToken).toBe('other-tab-access-token');
+    expect(result.current.refreshToken).toBe('other-tab-refresh-token');
+    expect(redirectToLogin).not.toHaveBeenCalled();
+  });
+});
+
+interface WrapperOptions {
+  queryClient?: QueryClient;
+  redirectToLogin?: () => void;
+  strict?: boolean;
+}
+
+function createWrapper(options: WrapperOptions = {}) {
+  const queryClient = options.queryClient ?? new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  });
+  return function Wrapper({ children }: PropsWithChildren) {
+    const content = (
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider
+          storage={window.localStorage}
+          redirectToLogin={options.redirectToLogin ?? vi.fn()}
+        >
+          {children}
+        </AuthProvider>
+      </QueryClientProvider>
+    );
+    return options.strict ? <StrictMode>{content}</StrictMode> : content;
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+function installSequentialWebLocks() {
+  let lockTail = Promise.resolve();
+  const requestLock = vi.fn((
+    _name: string,
+    optionsOrTask: unknown,
+    possibleTask?: () => Promise<unknown>
+  ) => {
+    const task = typeof optionsOrTask === 'function'
+      ? optionsOrTask as () => Promise<unknown>
+      : possibleTask;
+    if (!task) {
+      throw new Error('A lock callback is required');
+    }
+    const result = lockTail.then(task);
+    lockTail = result.then(() => undefined, () => undefined);
+    return result;
+  });
+  Object.defineProperty(navigator, 'locks', {
+    configurable: true,
+    value: { request: requestLock }
+  });
+  return requestLock;
+}

--- a/frontend/src/features/auth/AuthContext.tsx
+++ b/frontend/src/features/auth/AuthContext.tsx
@@ -1,0 +1,602 @@
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  createContext,
+  type PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+import {
+  API_BASE_URL,
+  ApiClient,
+  AuthenticationSupersededError
+} from '../../lib/api/client';
+import type { AuthResponse, UserProfile } from '../../lib/api/types';
+import {
+  login as loginRequest,
+  logout as logoutRequest,
+  refresh as refreshRequest,
+  register as registerRequest,
+  type LoginRequest,
+  type RegisterRequest
+} from './authApi';
+import {
+  AUTH_GENERATION_STORAGE_KEY,
+  AUTH_SESSION_STORAGE_KEY,
+  advanceAuthGeneration,
+  clearAuthSession,
+  createAuthSession,
+  readAuthGeneration,
+  type AuthSession,
+  readAuthSession,
+  writeAuthSession
+} from './authStorage';
+
+const REFRESH_WINDOW_MILLISECONDS = 30_000;
+const AUTH_SESSION_LOCK_NAME = 'vod.auth.session.v1';
+const REFRESH_TIMEOUT_MILLISECONDS = 10_000;
+const TOKEN_REVOCATION_TIMEOUT_MILLISECONDS = 5_000;
+
+export interface AuthContextValue {
+  user: UserProfile | null;
+  accessToken: string | null;
+  refreshToken: string | null;
+  isAuthenticated: boolean;
+  isInitializing: boolean;
+  isLoading: boolean;
+  error: Error | null;
+  login(request: LoginRequest): Promise<UserProfile>;
+  register(request: RegisterRequest): Promise<UserProfile>;
+  logout(): Promise<void>;
+  refreshTokens(): Promise<void>;
+  clearError(): void;
+}
+
+interface AuthProviderProps extends PropsWithChildren {
+  storage?: Storage;
+  redirectToLogin?: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+const ApiClientContext = createContext<ApiClient | null>(null);
+
+export function AuthProvider({
+  children,
+  storage = window.localStorage,
+  redirectToLogin = defaultRedirectToLogin
+}: AuthProviderProps) {
+  const queryClient = useQueryClient();
+  const [session, setSession] = useState<AuthSession | null>(null);
+  const [isInitializing, setIsInitializing] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const sessionRef = useRef<AuthSession | null>(null);
+  const sessionRevisionRef = useRef(0);
+  const pendingOperationsRef = useRef(0);
+  const latestOperationRef = useRef(0);
+  const logoutInProgressRef = useRef(false);
+  const refreshInFlightRef = useRef<Promise<AuthSession> | null>(null);
+  const bootstrapStartedRef = useRef(false);
+  const authenticationFailureHandledRef = useRef(false);
+  const refreshAccessTokenRef = useRef<() => Promise<string>>(
+    () => Promise.reject(new Error('Authentication provider is not ready'))
+  );
+  const authenticationFailureRef = useRef<(failure: unknown) => void>(() => undefined);
+  const apiClientRef = useRef<ApiClient | null>(null);
+
+  if (!apiClientRef.current) {
+    apiClientRef.current = new ApiClient(API_BASE_URL, {
+      getAuthenticationSnapshot: () => {
+        const currentSession = sessionRef.current;
+        const persistedSession = readAuthSession(storage);
+        const currentGeneration = readAuthGeneration(storage);
+        if (!currentSession
+          || !persistedSession
+          || currentSession.authGeneration !== currentGeneration
+          || persistedSession.authGeneration !== currentGeneration
+          || currentSession.user.id !== persistedSession.user.id
+          || currentSession.accessToken !== persistedSession.accessToken
+          || currentSession.refreshToken !== persistedSession.refreshToken) {
+          return null;
+        }
+        return {
+          userId: currentSession.user.id,
+          accessToken: currentSession.accessToken,
+          generation: currentSession.authGeneration
+        };
+      },
+      refreshAccessToken: () => refreshAccessTokenRef.current(),
+      onAuthenticationFailure: (failure) => authenticationFailureRef.current(failure)
+    });
+  }
+  const apiClient = apiClientRef.current;
+
+  const commitSession = useCallback((nextSession: AuthSession, expectedGeneration: number) => {
+    if (readAuthGeneration(storage) !== expectedGeneration) {
+      throw new AuthenticationSupersededError();
+    }
+    if (sessionRef.current && sessionRef.current.user.id !== nextSession.user.id) {
+      queryClient.clear();
+    }
+    writeAuthSession(nextSession, storage);
+    if (readAuthGeneration(storage) !== expectedGeneration) {
+      clearAuthSession(storage);
+      throw new AuthenticationSupersededError();
+    }
+    sessionRevisionRef.current += 1;
+    sessionRef.current = nextSession;
+    authenticationFailureHandledRef.current = false;
+    setSession(nextSession);
+  }, [queryClient, storage]);
+
+  const restoreSession = useCallback((storedSession: AuthSession) => {
+    if (storedSession.authGeneration !== readAuthGeneration(storage)) {
+      clearAuthSession(storage);
+      sessionRevisionRef.current += 1;
+      sessionRef.current = null;
+      setSession(null);
+      queryClient.clear();
+      return null;
+    }
+    if (sessionRef.current && sessionRef.current.user.id !== storedSession.user.id) {
+      queryClient.clear();
+    }
+    sessionRevisionRef.current += 1;
+    sessionRef.current = storedSession;
+    authenticationFailureHandledRef.current = false;
+    setSession(storedSession);
+    return storedSession;
+  }, [queryClient, storage]);
+
+  const clearMemorySession = useCallback(() => {
+    sessionRevisionRef.current += 1;
+    sessionRef.current = null;
+    setSession(null);
+    queryClient.clear();
+  }, [queryClient]);
+
+  const clearSession = useCallback(() => {
+    clearMemorySession();
+    clearAuthSession(storage);
+  }, [clearMemorySession, storage]);
+
+  const beginOperation = useCallback(() => {
+    const operationId = latestOperationRef.current + 1;
+    latestOperationRef.current = operationId;
+    pendingOperationsRef.current += 1;
+    setIsLoading(true);
+    setError(null);
+    return operationId;
+  }, []);
+
+  const finishOperation = useCallback(() => {
+    pendingOperationsRef.current = Math.max(0, pendingOperationsRef.current - 1);
+    setIsLoading(pendingOperationsRef.current > 0);
+  }, []);
+
+  const setLatestOperationError = useCallback((operationId: number, failure: unknown) => {
+    if (latestOperationRef.current === operationId) {
+      setError(asError(failure));
+    }
+  }, []);
+
+  const handleAuthenticationFailure = useCallback((failure: unknown) => {
+    if (authenticationFailureHandledRef.current) {
+      return;
+    }
+    authenticationFailureHandledRef.current = true;
+    clearSession();
+    setError(asError(failure));
+    redirectToLogin();
+  }, [clearSession, redirectToLogin]);
+
+  const performRefresh = useCallback((): Promise<AuthSession> => {
+    if (logoutInProgressRef.current) {
+      return Promise.reject(new Error('Logout is already in progress'));
+    }
+    if (refreshInFlightRef.current) {
+      return refreshInFlightRef.current;
+    }
+    const currentSession = sessionRef.current;
+    if (!currentSession) {
+      return Promise.reject(new Error('No refresh token is available'));
+    }
+
+    const startingRevision = sessionRevisionRef.current;
+    const startingGeneration = currentSession.authGeneration;
+    const attemptedRefreshToken = currentSession.refreshToken;
+    const abortController = new AbortController();
+    const timeoutId = window.setTimeout(
+      () => abortController.abort(),
+      REFRESH_TIMEOUT_MILLISECONDS
+    );
+    const refreshPromise = withAuthSessionLock(async () => {
+      if (readAuthGeneration(storage) !== startingGeneration) {
+        clearMemorySession();
+        throw new AuthenticationSupersededError();
+      }
+      if (sessionRevisionRef.current !== startingRevision) {
+        const latestSession = sessionRef.current;
+        if (latestSession) {
+          return latestSession;
+        }
+        throw new AuthenticationSupersededError();
+      }
+
+      const storedSession = readAuthSession(storage);
+      if (!storedSession) {
+        clearMemorySession();
+        throw new AuthenticationSupersededError();
+      }
+      if (storedSession.refreshToken !== attemptedRefreshToken) {
+        const restoredSession = restoreSession(storedSession);
+        if (restoredSession) {
+          return restoredSession;
+        }
+        throw new AuthenticationSupersededError();
+      }
+
+      let response: AuthResponse;
+      try {
+        response = await refreshRequest(
+          apiClient,
+          attemptedRefreshToken,
+          abortController.signal
+        );
+      } catch (failure) {
+        if (readAuthGeneration(storage) !== startingGeneration) {
+          clearMemorySession();
+          throw new AuthenticationSupersededError();
+        }
+        if (sessionRevisionRef.current !== startingRevision) {
+          const latestSession = sessionRef.current;
+          if (latestSession) {
+            return latestSession;
+          }
+          throw new AuthenticationSupersededError();
+        }
+
+        const rotatedSession = readAuthSession(storage);
+        if (!rotatedSession) {
+          clearMemorySession();
+          throw new AuthenticationSupersededError();
+        }
+        if (rotatedSession.refreshToken !== attemptedRefreshToken) {
+          const restoredSession = restoreSession(rotatedSession);
+          if (restoredSession) {
+            return restoredSession;
+          }
+          throw new AuthenticationSupersededError();
+        }
+        throw failure;
+      }
+
+      const persistedSession = readAuthSession(storage);
+      if (readAuthGeneration(storage) !== startingGeneration
+        || !persistedSession
+        || persistedSession.authGeneration !== startingGeneration
+        || persistedSession.user.id !== currentSession.user.id
+        || persistedSession.refreshToken !== attemptedRefreshToken) {
+        await revokeUnusedRefreshToken(apiClient, response.refreshToken);
+        if (readAuthGeneration(storage) === persistedSession?.authGeneration
+          && persistedSession
+          && persistedSession.refreshToken !== attemptedRefreshToken
+          && sessionRef.current?.refreshToken !== persistedSession.refreshToken) {
+          restoreSession(persistedSession);
+        }
+        const latestSession = sessionRef.current;
+        if (latestSession && latestSession.refreshToken !== attemptedRefreshToken) {
+          return latestSession;
+        }
+        clearMemorySession();
+        throw new AuthenticationSupersededError();
+      }
+
+      const nextSession = createAuthSession(response, Date.now(), startingGeneration);
+      try {
+        commitSession(nextSession, startingGeneration);
+      } catch (failure) {
+        if (readAuthGeneration(storage) !== startingGeneration) {
+          clearMemorySession();
+        }
+        await revokeUnusedRefreshToken(apiClient, response.refreshToken);
+        throw failure;
+      }
+      return nextSession;
+    }, abortController.signal).finally(() => window.clearTimeout(timeoutId));
+    refreshInFlightRef.current = refreshPromise;
+    refreshPromise.then(
+      () => {
+        if (refreshInFlightRef.current === refreshPromise) {
+          refreshInFlightRef.current = null;
+        }
+      },
+      () => {
+        if (refreshInFlightRef.current === refreshPromise) {
+          refreshInFlightRef.current = null;
+        }
+      }
+    );
+    return refreshPromise;
+  }, [apiClient, clearMemorySession, commitSession, restoreSession, storage]);
+
+  refreshAccessTokenRef.current = async () => (await performRefresh()).accessToken;
+  authenticationFailureRef.current = handleAuthenticationFailure;
+
+  const refreshTokens = useCallback(async () => {
+    beginOperation();
+    try {
+      await performRefresh();
+    } catch (failure) {
+      handleAuthenticationFailure(failure);
+      throw failure;
+    } finally {
+      finishOperation();
+    }
+  }, [beginOperation, finishOperation, handleAuthenticationFailure, performRefresh]);
+
+  useEffect(() => {
+    if (bootstrapStartedRef.current) {
+      return;
+    }
+    bootstrapStartedRef.current = true;
+    const storedSession = readAuthSession(storage);
+    if (!storedSession) {
+      setIsInitializing(false);
+      return;
+    }
+
+    if (!restoreSession(storedSession)) {
+      setIsInitializing(false);
+      return;
+    }
+    if (storedSession.accessTokenExpiresAt > Date.now() + REFRESH_WINDOW_MILLISECONDS) {
+      setIsInitializing(false);
+      return;
+    }
+
+    void refreshTokens().catch(() => undefined).finally(() => setIsInitializing(false));
+  }, [refreshTokens, restoreSession, storage]);
+
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== null
+        && event.key !== AUTH_SESSION_STORAGE_KEY
+        && event.key !== AUTH_GENERATION_STORAGE_KEY) {
+        return;
+      }
+      const externalSession = readAuthSession(storage);
+      if (externalSession) {
+        if (restoreSession(externalSession)) {
+          setError(null);
+        }
+      } else {
+        clearMemorySession();
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, [clearMemorySession, restoreSession, storage]);
+
+  const login = useCallback(async (request: LoginRequest) => {
+    if (logoutInProgressRef.current) {
+      throw new Error('Logout is already in progress');
+    }
+    const operationId = beginOperation();
+    const operationGeneration = readAuthGeneration(storage);
+    try {
+      const response = await loginRequest(apiClient, request);
+      try {
+        await withAuthSessionLock(async () => {
+          if (latestOperationRef.current !== operationId) {
+            throw new AuthenticationSupersededError();
+          }
+          commitSession(
+            createAuthSession(response, Date.now(), operationGeneration),
+            operationGeneration
+          );
+        });
+      } catch (failure) {
+        if (readAuthGeneration(storage) !== operationGeneration) {
+          clearMemorySession();
+        }
+        await revokeUnusedRefreshToken(apiClient, response.refreshToken);
+        throw failure;
+      }
+      return response.user;
+    } catch (failure) {
+      setLatestOperationError(operationId, failure);
+      throw failure;
+    } finally {
+      finishOperation();
+    }
+  }, [
+    apiClient,
+    beginOperation,
+    clearMemorySession,
+    commitSession,
+    finishOperation,
+    setLatestOperationError,
+    storage
+  ]);
+
+  const register = useCallback(async (request: RegisterRequest) => {
+    if (logoutInProgressRef.current) {
+      throw new Error('Logout is already in progress');
+    }
+    const operationId = beginOperation();
+    try {
+      return await registerRequest(apiClient, request);
+    } catch (failure) {
+      setLatestOperationError(operationId, failure);
+      throw failure;
+    } finally {
+      finishOperation();
+    }
+  }, [apiClient, beginOperation, finishOperation, setLatestOperationError]);
+
+  const logout = useCallback(async () => {
+    if (logoutInProgressRef.current) {
+      return;
+    }
+    logoutInProgressRef.current = true;
+    const operationId = beginOperation();
+    let transportFailure: unknown;
+    const memoryRefreshToken = sessionRef.current?.refreshToken;
+    const beforeGenerationToken = readAuthSession(storage)?.refreshToken;
+    const logoutGeneration = advanceAuthGeneration(storage);
+    const afterGenerationToken = readAuthSession(storage)?.refreshToken;
+    clearAuthSession(storage);
+    authenticationFailureHandledRef.current = true;
+    clearMemorySession();
+    try {
+      await revokeLatestSessionTokens(
+        apiClient,
+        storage,
+        [memoryRefreshToken, beforeGenerationToken, afterGenerationToken],
+        logoutGeneration
+      );
+    } catch (failure) {
+      transportFailure = failure;
+      setLatestOperationError(operationId, failure);
+    } finally {
+      logoutInProgressRef.current = false;
+      finishOperation();
+    }
+    if (transportFailure) {
+      throw transportFailure;
+    }
+  }, [apiClient, beginOperation, clearMemorySession, finishOperation, setLatestOperationError, storage]);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  const value = useMemo<AuthContextValue>(() => ({
+    user: session?.user ?? null,
+    accessToken: session?.accessToken ?? null,
+    refreshToken: session?.refreshToken ?? null,
+    isAuthenticated: session !== null,
+    isInitializing,
+    isLoading,
+    error,
+    login,
+    register,
+    logout,
+    refreshTokens,
+    clearError
+  }), [clearError, error, isInitializing, isLoading, login, logout, refreshTokens, register, session]);
+
+  return (
+    <ApiClientContext.Provider value={apiClient}>
+      <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+    </ApiClientContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return context;
+}
+
+export function useApiClient(): ApiClient {
+  const context = useContext(ApiClientContext);
+  if (!context) {
+    throw new Error('useApiClient must be used within AuthProvider');
+  }
+  return context;
+}
+
+function defaultRedirectToLogin(): void {
+  if (window.location.pathname !== '/login') {
+    window.location.assign('/login');
+  }
+}
+
+function asError(value: unknown): Error {
+  return value instanceof Error ? value : new Error('Authentication request failed');
+}
+
+function withAuthSessionLock<T>(
+  task: () => Promise<T>,
+  signal?: AbortSignal
+): Promise<T> {
+  if (navigator.locks) {
+    return signal
+      ? navigator.locks.request(AUTH_SESSION_LOCK_NAME, { signal }, task)
+      : navigator.locks.request(AUTH_SESSION_LOCK_NAME, task);
+  }
+  return task();
+}
+
+async function revokeRefreshToken(client: ApiClient, refreshToken: string): Promise<void> {
+  const abortController = new AbortController();
+  const timeoutId = window.setTimeout(
+    () => abortController.abort(),
+    TOKEN_REVOCATION_TIMEOUT_MILLISECONDS
+  );
+  try {
+    await logoutRequest(client, refreshToken, abortController.signal);
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+}
+
+async function revokeUnusedRefreshToken(client: ApiClient, refreshToken: string): Promise<void> {
+  try {
+    await revokeRefreshToken(client, refreshToken);
+  } catch {
+    // A superseded session must never replace current state, even when revocation is unavailable.
+  }
+}
+
+async function revokeLatestSessionTokens(
+  client: ApiClient,
+  storage: Storage,
+  fallbackRefreshTokens: Array<string | undefined>,
+  logoutGeneration: number
+): Promise<void> {
+  const abortController = new AbortController();
+  const timeoutId = window.setTimeout(
+    () => abortController.abort(),
+    TOKEN_REVOCATION_TIMEOUT_MILLISECONDS
+  );
+  try {
+    await withAuthSessionLock(
+      async () => {
+        const racingSession = readAuthSession(storage);
+        const racingRefreshToken = racingSession
+          && racingSession.authGeneration < logoutGeneration
+          ? racingSession.refreshToken
+          : undefined;
+        if (racingRefreshToken) {
+          clearAuthSession(storage);
+        }
+        const tokens = Array.from(new Set(
+          [racingRefreshToken, ...fallbackRefreshTokens].filter(
+            (token): token is string => Boolean(token)
+          )
+        ));
+        const results = await Promise.allSettled(tokens.map((token) => logoutRequest(
+          client,
+          token,
+          abortController.signal
+        )));
+        const failedRevocation = results.find(
+          (result): result is PromiseRejectedResult => result.status === 'rejected'
+        );
+        if (failedRevocation) {
+          throw failedRevocation.reason;
+        }
+      },
+      abortController.signal
+    );
+  } finally {
+    abortController.abort();
+    window.clearTimeout(timeoutId);
+  }
+}

--- a/frontend/src/features/auth/authApi.test.ts
+++ b/frontend/src/features/auth/authApi.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiClient } from '../../lib/api/client';
+import { InvalidAuthResponseError, login, refresh, register } from './authApi';
+
+const validUser = {
+  id: '3fcf25c2-f096-4462-ae63-4ba4702a9078',
+  email: 'viewer@example.com',
+  displayName: 'Viewer',
+  roles: ['ROLE_USER']
+};
+
+const validAuthResponse = {
+  user: validUser,
+  accessToken: 'access-token',
+  refreshToken: 'refresh-token',
+  expiresInSeconds: 900
+};
+
+describe('auth API response decoding', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+  const client = new ApiClient('/api/v1', {
+    getAuthenticationSnapshot: () => null,
+    refreshAccessToken: vi.fn(),
+    onAuthenticationFailure: vi.fn()
+  });
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('decodes login and refresh AuthResponse payloads', async () => {
+    fetchMock.mockImplementation(() => Promise.resolve(jsonResponse(validAuthResponse)));
+
+    await expect(login(client, {
+      email: 'viewer@example.com',
+      password: 'strong-password'
+    })).resolves.toEqual(validAuthResponse);
+    await expect(refresh(client, 'refresh-token')).resolves.toEqual(validAuthResponse);
+  });
+
+  it('rejects an incomplete AuthResponse before it reaches auth state', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({
+      ...validAuthResponse,
+      refreshToken: ''
+    }));
+
+    await expect(login(client, {
+      email: 'viewer@example.com',
+      password: 'strong-password'
+    })).rejects.toBeInstanceOf(InvalidAuthResponseError);
+  });
+
+  it('decodes registration UserProfile and rejects unknown roles', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(validUser, 201))
+      .mockResolvedValueOnce(jsonResponse({
+        ...validUser,
+        roles: ['ROLE_SUPERUSER']
+      }, 201));
+
+    const request = {
+      email: 'viewer@example.com',
+      password: 'strong-password',
+      displayName: 'Viewer'
+    };
+    await expect(register(client, request)).resolves.toEqual(validUser);
+    await expect(register(client, request)).rejects.toBeInstanceOf(InvalidAuthResponseError);
+  });
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}

--- a/frontend/src/features/auth/authApi.ts
+++ b/frontend/src/features/auth/authApi.ts
@@ -1,0 +1,121 @@
+import { ApiClient } from '../../lib/api/client';
+import type { AuthResponse, UserProfile, UserRole } from '../../lib/api/types';
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface RegisterRequest {
+  email: string;
+  password: string;
+  displayName: string;
+}
+
+export async function login(client: ApiClient, request: LoginRequest): Promise<AuthResponse> {
+  const response = await client.request<unknown>('/auth/login', {
+    method: 'POST',
+    json: request
+  });
+  return decodeAuthResponse(response);
+}
+
+export async function register(client: ApiClient, request: RegisterRequest): Promise<UserProfile> {
+  const response = await client.request<unknown>('/auth/register', {
+    method: 'POST',
+    json: request
+  });
+  return decodeUserProfile(response);
+}
+
+export async function refresh(
+  client: ApiClient,
+  refreshToken: string,
+  signal?: AbortSignal
+): Promise<AuthResponse> {
+  const response = await client.request<unknown>('/auth/refresh', {
+    method: 'POST',
+    json: { refreshToken },
+    signal
+  });
+  return decodeAuthResponse(response);
+}
+
+export function logout(
+  client: ApiClient,
+  refreshToken: string,
+  signal?: AbortSignal
+): Promise<void> {
+  return client.request('/auth/logout', {
+    method: 'POST',
+    json: { refreshToken },
+    signal
+  });
+}
+
+export class InvalidAuthResponseError extends Error {
+  constructor(contractName: 'AuthResponse' | 'UserProfile') {
+    super(`Server returned an invalid ${contractName}`);
+    this.name = 'InvalidAuthResponseError';
+  }
+}
+
+function decodeAuthResponse(value: unknown): AuthResponse {
+  if (!value || typeof value !== 'object') {
+    throw new InvalidAuthResponseError('AuthResponse');
+  }
+  const candidate = value as Record<string, unknown>;
+  const user = tryDecodeUserProfile(candidate.user);
+  if (!user
+    || !nonEmptyString(candidate.accessToken)
+    || !nonEmptyString(candidate.refreshToken)
+    || !positiveInteger(candidate.expiresInSeconds)) {
+    throw new InvalidAuthResponseError('AuthResponse');
+  }
+  return {
+    user,
+    accessToken: candidate.accessToken,
+    refreshToken: candidate.refreshToken,
+    expiresInSeconds: candidate.expiresInSeconds
+  };
+}
+
+function decodeUserProfile(value: unknown): UserProfile {
+  const user = tryDecodeUserProfile(value);
+  if (!user) {
+    throw new InvalidAuthResponseError('UserProfile');
+  }
+  return user;
+}
+
+function tryDecodeUserProfile(value: unknown): UserProfile | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const candidate = value as Record<string, unknown>;
+  if (!nonEmptyString(candidate.id)
+    || !nonEmptyString(candidate.email)
+    || typeof candidate.displayName !== 'string'
+    || !Array.isArray(candidate.roles)
+    || !candidate.roles.every(isUserRole)) {
+    return null;
+  }
+  return {
+    id: candidate.id,
+    email: candidate.email,
+    displayName: candidate.displayName,
+    roles: [...candidate.roles]
+  };
+}
+
+function isUserRole(value: unknown): value is UserRole {
+  return value === 'ROLE_USER' || value === 'ROLE_ADMIN';
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function positiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0;
+}

--- a/frontend/src/features/auth/authStorage.test.ts
+++ b/frontend/src/features/auth/authStorage.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  AUTH_GENERATION_STORAGE_KEY,
+  AUTH_SESSION_STORAGE_KEY,
+  advanceAuthGeneration,
+  clearAuthSession,
+  createAuthSession,
+  readAuthGeneration,
+  readAuthSession,
+  writeAuthSession
+} from './authStorage';
+import type { AuthResponse } from '../../lib/api/types';
+
+const authResponse: AuthResponse = {
+  user: {
+    id: '3fcf25c2-f096-4462-ae63-4ba4702a9078',
+    email: 'viewer@example.com',
+    displayName: 'Viewer',
+    roles: ['ROLE_USER']
+  },
+  accessToken: 'access-token',
+  refreshToken: 'refresh-token',
+  expiresInSeconds: 900
+};
+
+describe('auth session storage', () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it('round-trips a versioned session and derives its access-token expiry', () => {
+    const session = createAuthSession(authResponse, 1_000);
+
+    writeAuthSession(session, window.localStorage);
+
+    expect(session.accessTokenExpiresAt).toBe(901_000);
+    expect(readAuthSession(window.localStorage)).toEqual(session);
+  });
+
+  it('fails closed and removes malformed or unknown-version storage', () => {
+    window.localStorage.setItem(AUTH_SESSION_STORAGE_KEY, '{not-json');
+    expect(readAuthSession(window.localStorage)).toBeNull();
+    expect(window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toBeNull();
+
+    window.localStorage.setItem(
+      AUTH_SESSION_STORAGE_KEY,
+      JSON.stringify({ version: 99, session: createAuthSession(authResponse) })
+    );
+    expect(readAuthSession(window.localStorage)).toBeNull();
+    expect(window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toBeNull();
+  });
+
+  it('clears the persisted session', () => {
+    writeAuthSession(createAuthSession(authResponse), window.localStorage);
+
+    clearAuthSession(window.localStorage);
+
+    expect(readAuthSession(window.localStorage)).toBeNull();
+  });
+
+  it('persists a monotonic logout generation independently of the session', () => {
+    expect(readAuthGeneration(window.localStorage)).toBe(0);
+
+    const firstGeneration = advanceAuthGeneration(window.localStorage);
+    const secondGeneration = advanceAuthGeneration(window.localStorage);
+
+    expect(firstGeneration).toBeGreaterThan(0);
+    expect(secondGeneration).toBeGreaterThan(firstGeneration);
+    expect(readAuthGeneration(window.localStorage)).toBe(secondGeneration);
+    expect(window.localStorage.getItem(AUTH_GENERATION_STORAGE_KEY))
+      .toBe(String(secondGeneration));
+  });
+
+  it('rejects a stored session without a valid auth generation', () => {
+    const session = createAuthSession(authResponse);
+    window.localStorage.setItem(AUTH_SESSION_STORAGE_KEY, JSON.stringify({
+      version: 1,
+      session: { ...session, authGeneration: -1 }
+    }));
+
+    expect(readAuthSession(window.localStorage)).toBeNull();
+    expect(window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/frontend/src/features/auth/authStorage.ts
+++ b/frontend/src/features/auth/authStorage.ts
@@ -1,0 +1,150 @@
+import type { AuthResponse, UserProfile, UserRole } from '../../lib/api/types';
+
+export const AUTH_SESSION_STORAGE_KEY = 'vod.auth.session.v1';
+export const AUTH_GENERATION_STORAGE_KEY = 'vod.auth.generation.v1';
+const STORAGE_VERSION = 1;
+
+export interface AuthSession extends AuthResponse {
+  accessTokenExpiresAt: number;
+  authGeneration: number;
+}
+
+interface StoredAuthSession {
+  version: typeof STORAGE_VERSION;
+  session: AuthSession;
+}
+
+export function createAuthSession(
+  response: AuthResponse,
+  now = Date.now(),
+  authGeneration = 0
+): AuthSession {
+  return {
+    ...response,
+    user: { ...response.user, roles: [...response.user.roles] },
+    accessTokenExpiresAt: now + response.expiresInSeconds * 1_000,
+    authGeneration
+  };
+}
+
+export function readAuthGeneration(storage: Storage): number {
+  try {
+    const raw = storage.getItem(AUTH_GENERATION_STORAGE_KEY);
+    if (raw === null) {
+      return 0;
+    }
+    const generation = Number(raw);
+    if (Number.isSafeInteger(generation) && generation >= 0) {
+      return generation;
+    }
+
+    const recoveredGeneration = Date.now();
+    storage.setItem(AUTH_GENERATION_STORAGE_KEY, String(recoveredGeneration));
+    return recoveredGeneration;
+  } catch {
+    return Number.MAX_SAFE_INTEGER;
+  }
+}
+
+export function advanceAuthGeneration(storage: Storage): number {
+  const currentGeneration = readAuthGeneration(storage);
+  const nextGeneration = currentGeneration < Number.MAX_SAFE_INTEGER
+    ? Math.max(currentGeneration + 1, Date.now())
+    : currentGeneration;
+  try {
+    storage.setItem(AUTH_GENERATION_STORAGE_KEY, String(nextGeneration));
+  } catch {
+    // The current tab still fails closed in memory when storage is unavailable.
+  }
+  return nextGeneration;
+}
+
+export function readAuthSession(storage: Storage): AuthSession | null {
+  let raw: string | null;
+  try {
+    raw = storage.getItem(AUTH_SESSION_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const stored = JSON.parse(raw) as unknown;
+    if (isStoredAuthSession(stored)) {
+      return stored.session;
+    }
+  } catch {
+    // Malformed authentication state must fail closed.
+  }
+
+  try {
+    storage.removeItem(AUTH_SESSION_STORAGE_KEY);
+  } catch {
+    // Memory state still fails closed when browser storage is unavailable.
+  }
+  return null;
+}
+
+export function writeAuthSession(session: AuthSession, storage: Storage): void {
+  const stored: StoredAuthSession = { version: STORAGE_VERSION, session };
+  storage.setItem(AUTH_SESSION_STORAGE_KEY, JSON.stringify(stored));
+}
+
+export function clearAuthSession(storage: Storage): void {
+  try {
+    storage.removeItem(AUTH_SESSION_STORAGE_KEY);
+  } catch {
+    // Reads also fail closed when browser storage is unavailable.
+  }
+}
+
+function isStoredAuthSession(value: unknown): value is StoredAuthSession {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const stored = value as Partial<StoredAuthSession>;
+  return stored.version === STORAGE_VERSION && isAuthSession(stored.session);
+}
+
+function isAuthSession(value: unknown): value is AuthSession {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const session = value as Partial<AuthSession>;
+  return isUserProfile(session.user)
+    && nonEmptyString(session.accessToken)
+    && nonEmptyString(session.refreshToken)
+    && positiveNumber(session.expiresInSeconds)
+    && positiveNumber(session.accessTokenExpiresAt)
+    && nonNegativeInteger(session.authGeneration);
+}
+
+function isUserProfile(value: unknown): value is UserProfile {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const user = value as Partial<UserProfile>;
+  return nonEmptyString(user.id)
+    && nonEmptyString(user.email)
+    && typeof user.displayName === 'string'
+    && Array.isArray(user.roles)
+    && user.roles.every(isUserRole);
+}
+
+function isUserRole(value: unknown): value is UserRole {
+  return value === 'ROLE_USER' || value === 'ROLE_ADMIN';
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function positiveNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+function nonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}

--- a/frontend/src/lib/api/client.test.ts
+++ b/frontend/src/lib/api/client.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ApiClient,
+  ApiRequestError,
+  AuthenticationSupersededError,
+  type AuthenticationSnapshot
+} from './client';
+
+describe('ApiClient', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('attaches the bearer token to authenticated requests', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ status: 'ok' }));
+    const client = new ApiClient('/api/v1', {
+      getAuthenticationSnapshot: () => authentication('user-1', 'access-token'),
+      refreshAccessToken: vi.fn(),
+      onAuthenticationFailure: vi.fn()
+    });
+
+    await client.request('/users/me', { authenticated: true });
+
+    const headers = new Headers(fetchMock.mock.calls[0][1]?.headers);
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/users/me');
+    expect(headers.get('Authorization')).toBe('Bearer access-token');
+  });
+
+  it('single-flights rotating refresh and retries concurrent requests once', async () => {
+    let token = 'expired-token';
+    const refreshAccessToken = vi.fn(async () => {
+      token = 'rotated-token';
+      return token;
+    });
+    fetchMock.mockImplementation(async (_input, init) => {
+      const authorization = new Headers(init?.headers).get('Authorization');
+      return authorization === 'Bearer rotated-token'
+        ? jsonResponse({ status: 'ok' })
+        : jsonResponse({ code: 'UNAUTHORIZED' }, 401);
+    });
+    const client = new ApiClient('/api/v1', {
+      getAuthenticationSnapshot: () => authentication('user-1', token),
+      refreshAccessToken,
+      onAuthenticationFailure: vi.fn()
+    });
+
+    await Promise.all([
+      client.request('/movies', { authenticated: true }),
+      client.request('/users/me', { authenticated: true })
+    ]);
+
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('retries a delayed old-token 401 with the already-rotated token', async () => {
+    let token = 'expired-token';
+    let expiredTokenCalls = 0;
+    let resolveDelayedResponse: ((response: Response) => void) | undefined;
+    const refreshAccessToken = vi.fn(async () => {
+      token = 'rotated-token';
+      return token;
+    });
+    fetchMock.mockImplementation((_input, init) => {
+      const authorization = new Headers(init?.headers).get('Authorization');
+      if (authorization === 'Bearer rotated-token') {
+        return Promise.resolve(jsonResponse({ status: 'ok' }));
+      }
+      expiredTokenCalls += 1;
+      if (expiredTokenCalls === 2) {
+        return new Promise<Response>((resolve) => {
+          resolveDelayedResponse = resolve;
+        });
+      }
+      return Promise.resolve(jsonResponse({ code: 'UNAUTHORIZED' }, 401));
+    });
+    const client = new ApiClient('/api/v1', {
+      getAuthenticationSnapshot: () => authentication('user-1', token),
+      refreshAccessToken,
+      onAuthenticationFailure: vi.fn()
+    });
+
+    const firstRequest = client.request('/movies', { authenticated: true });
+    const delayedRequest = client.request('/users/me', { authenticated: true });
+    await firstRequest;
+    resolveDelayedResponse?.(jsonResponse({ code: 'UNAUTHORIZED' }, 401));
+    await delayedRequest;
+
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not replay a request under a different user identity', async () => {
+    let currentAuthentication = authentication('user-a', 'token-a');
+    let resolveInitialResponse: ((response: Response) => void) | undefined;
+    fetchMock.mockReturnValue(new Promise<Response>((resolve) => {
+      resolveInitialResponse = resolve;
+    }));
+    const refreshAccessToken = vi.fn();
+    const onAuthenticationFailure = vi.fn();
+    const client = new ApiClient('/api/v1', {
+      getAuthenticationSnapshot: () => currentAuthentication,
+      refreshAccessToken,
+      onAuthenticationFailure
+    });
+
+    const request = client.request('/watchlist', {
+      method: 'POST',
+      authenticated: true,
+      json: { movieId: 'movie-1' }
+    });
+    currentAuthentication = authentication('user-b', 'token-b');
+    resolveInitialResponse?.(jsonResponse(apiError(), 401));
+
+    await expect(request).rejects.toBeInstanceOf(AuthenticationSupersededError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+    expect(onAuthenticationFailure).not.toHaveBeenCalled();
+  });
+
+  it('rejects a delayed successful response after the user identity changes', async () => {
+    let currentAuthentication = authentication('user-a', 'token-a');
+    let resolveResponse: ((response: Response) => void) | undefined;
+    fetchMock.mockReturnValue(new Promise<Response>((resolve) => {
+      resolveResponse = resolve;
+    }));
+    const client = new ApiClient('/api/v1', {
+      getAuthenticationSnapshot: () => currentAuthentication,
+      refreshAccessToken: vi.fn(),
+      onAuthenticationFailure: vi.fn()
+    });
+
+    const request = client.request('/users/me', { authenticated: true });
+    currentAuthentication = authentication('user-b', 'token-b');
+    resolveResponse?.(jsonResponse({ id: 'user-a' }));
+
+    await expect(request).rejects.toBeInstanceOf(AuthenticationSupersededError);
+  });
+
+  it('rejects a delayed successful mutation after the user identity changes', async () => {
+    let currentAuthentication = authentication('user-a', 'token-a');
+    let resolveResponse: ((response: Response) => void) | undefined;
+    fetchMock.mockReturnValue(new Promise<Response>((resolve) => {
+      resolveResponse = resolve;
+    }));
+    const client = new ApiClient('/api/v1', {
+      getAuthenticationSnapshot: () => currentAuthentication,
+      refreshAccessToken: vi.fn(),
+      onAuthenticationFailure: vi.fn()
+    });
+
+    const request = client.request('/watchlist/movie-1', {
+      method: 'DELETE',
+      authenticated: true
+    });
+    currentAuthentication = authentication('user-b', 'token-b');
+    resolveResponse?.(new Response(null, { status: 204 }));
+
+    await expect(request).rejects.toBeInstanceOf(AuthenticationSupersededError);
+  });
+
+  it('rechecks user identity after a delayed response body is consumed', async () => {
+    let currentAuthentication = authentication('user-a', 'token-a');
+    let resolveBody: ((body: string) => void) | undefined;
+    let markBodyRead: (() => void) | undefined;
+    const bodyRead = new Promise<void>((resolve) => {
+      markBodyRead = resolve;
+    });
+    const response = new Response(null, {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    });
+    vi.spyOn(response, 'text').mockImplementation(() => {
+      markBodyRead?.();
+      return new Promise<string>((resolve) => {
+        resolveBody = resolve;
+      });
+    });
+    fetchMock.mockResolvedValue(response);
+    const client = new ApiClient('/api/v1', {
+      getAuthenticationSnapshot: () => currentAuthentication,
+      refreshAccessToken: vi.fn(),
+      onAuthenticationFailure: vi.fn()
+    });
+
+    const request = client.request('/users/me', { authenticated: true });
+    await bodyRead;
+    currentAuthentication = authentication('user-b', 'token-b');
+    resolveBody?.(JSON.stringify({ id: 'user-a' }));
+
+    await expect(request).rejects.toBeInstanceOf(AuthenticationSupersededError);
+  });
+
+  it('does not clear a newer token when an earlier retry returns 401', async () => {
+    let currentAuthentication = authentication('user-a', 'token-0');
+    let resolveRetryResponse: ((response: Response) => void) | undefined;
+    const retryResponse = new Promise<Response>((resolve) => {
+      resolveRetryResponse = resolve;
+    });
+    fetchMock.mockImplementation((_input, init) => {
+      const authorization = new Headers(init?.headers).get('Authorization');
+      return authorization === 'Bearer token-0'
+        ? Promise.resolve(jsonResponse(apiError(), 401))
+        : retryResponse;
+    });
+    const refreshAccessToken = vi.fn(async () => {
+      currentAuthentication = authentication('user-a', 'token-1');
+      return 'token-1';
+    });
+    const onAuthenticationFailure = vi.fn();
+    const client = new ApiClient('/api/v1', {
+      getAuthenticationSnapshot: () => currentAuthentication,
+      refreshAccessToken,
+      onAuthenticationFailure
+    });
+
+    const request = client.request('/users/me', { authenticated: true });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    currentAuthentication = authentication('user-a', 'token-2');
+    resolveRetryResponse?.(jsonResponse(apiError(), 401));
+
+    await expect(request).rejects.toBeInstanceOf(ApiRequestError);
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(onAuthenticationFailure).not.toHaveBeenCalled();
+  });
+
+  it('clears authentication after refresh failure or a retried 401', async () => {
+    let token = 'expired-token';
+    const onAuthenticationFailure = vi.fn();
+    fetchMock.mockResolvedValue(jsonResponse(apiError(), 401));
+    const client = new ApiClient('/api/v1', {
+      getAuthenticationSnapshot: () => authentication('user-1', token),
+      refreshAccessToken: vi.fn(async () => {
+        token = 'still-invalid-token';
+        return token;
+      }),
+      onAuthenticationFailure
+    });
+
+    await expect(client.request('/users/me', { authenticated: true }))
+      .rejects.toBeInstanceOf(ApiRequestError);
+
+    expect(onAuthenticationFailure).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats malformed optional API error fields as an unstructured error', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({
+      ...apiError(),
+      fieldErrors: [null]
+    }, 400));
+    const client = new ApiClient('/api/v1', {
+      getAuthenticationSnapshot: () => null,
+      refreshAccessToken: vi.fn(),
+      onAuthenticationFailure: vi.fn()
+    });
+
+    const request = client.request('/auth/register', { method: 'POST' });
+
+    await expect(request).rejects.toMatchObject({
+      message: 'Request failed with status 400',
+      apiError: null
+    });
+  });
+});
+
+function authentication(
+  userId: string,
+  accessToken: string,
+  generation = 0
+): AuthenticationSnapshot {
+  return { userId, accessToken, generation };
+}
+
+function apiError(): object {
+  return {
+    timestamp: '2026-08-21T15:00:00Z',
+    status: 401,
+    code: 'UNAUTHORIZED',
+    message: 'Authentication required'
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,0 +1,253 @@
+import type { ApiError } from './types';
+
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api/v1';
+
+export interface AuthenticationSnapshot {
+  userId: string;
+  accessToken: string;
+  generation: number;
+}
+
+export interface AuthRequestController {
+  getAuthenticationSnapshot(): AuthenticationSnapshot | null;
+  refreshAccessToken(): Promise<string>;
+  onAuthenticationFailure(error: unknown): void;
+}
+
+export interface ApiRequestOptions extends Omit<RequestInit, 'body'> {
+  authenticated?: boolean;
+  json?: unknown;
+}
+
+export class ApiRequestError extends Error {
+  readonly status: number;
+  readonly apiError: ApiError | null;
+
+  constructor(status: number, payload: unknown) {
+    const apiError = isApiError(payload) ? payload : null;
+    super(apiError?.message ?? `Request failed with status ${status}`);
+    this.name = 'ApiRequestError';
+    this.status = status;
+    this.apiError = apiError;
+  }
+}
+
+export class AuthenticationSupersededError extends Error {
+  constructor() {
+    super('Authentication changed while the operation was in progress');
+    this.name = 'AuthenticationSupersededError';
+  }
+}
+
+export class ApiClient {
+  private readonly baseUrl: string;
+  private readonly authController: AuthRequestController;
+  private refreshPromise: Promise<string> | null = null;
+
+  constructor(baseUrl: string, authController: AuthRequestController) {
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+    this.authController = authController;
+  }
+
+  async request<T>(path: string, options: ApiRequestOptions = {}): Promise<T> {
+    const authenticated = options.authenticated ?? false;
+    const initialAuthentication = authenticated
+      ? this.authController.getAuthenticationSnapshot()
+      : null;
+    const accessToken = initialAuthentication?.accessToken ?? null;
+    let response = await this.send(path, options, accessToken);
+
+    if (authenticated && response.status === 401) {
+      const currentAuthentication = this.authController.getAuthenticationSnapshot();
+      if (!sameIdentity(initialAuthentication, currentAuthentication)) {
+        throw new AuthenticationSupersededError();
+      }
+
+      if (currentAuthentication && currentAuthentication.accessToken !== accessToken) {
+        response = await this.send(path, options, currentAuthentication.accessToken);
+        if (response.status === 401) {
+          await this.throwAuthenticationFailure(response, currentAuthentication);
+        }
+      } else {
+        try {
+          await this.refreshAccessTokenOnce();
+        } catch (error) {
+          if (sameAuthentication(
+            initialAuthentication,
+            this.authController.getAuthenticationSnapshot()
+          )) {
+            this.authController.onAuthenticationFailure(error);
+          }
+          throw error;
+        }
+
+        const refreshedAuthentication = this.authController.getAuthenticationSnapshot();
+        if (!sameIdentity(initialAuthentication, refreshedAuthentication)) {
+          throw new AuthenticationSupersededError();
+        }
+        if (!refreshedAuthentication) {
+          const error = new AuthenticationSupersededError();
+          this.authController.onAuthenticationFailure(error);
+          throw error;
+        }
+
+        response = await this.send(path, options, refreshedAuthentication.accessToken);
+        if (response.status === 401) {
+          await this.throwAuthenticationFailure(response, refreshedAuthentication);
+        }
+      }
+    }
+
+    if (authenticated) {
+      this.assertCurrentIdentity(initialAuthentication);
+    }
+
+    if (!response.ok) {
+      const error = await responseError(response);
+      if (authenticated) {
+        this.assertCurrentIdentity(initialAuthentication);
+      }
+      throw error;
+    }
+
+    const payload = await responsePayload<T>(response);
+    if (authenticated) {
+      this.assertCurrentIdentity(initialAuthentication);
+    }
+    return payload;
+  }
+
+  private send(
+    path: string,
+    options: ApiRequestOptions,
+    accessToken: string | null
+  ): Promise<Response> {
+    const { authenticated: _authenticated, json, headers: initialHeaders, ...requestInit } = options;
+    const headers = new Headers(initialHeaders);
+    if (json !== undefined) {
+      headers.set('Content-Type', 'application/json');
+    }
+    if (accessToken) {
+      headers.set('Authorization', `Bearer ${accessToken}`);
+    }
+
+    return fetch(this.url(path), {
+      ...requestInit,
+      headers,
+      body: json === undefined ? undefined : JSON.stringify(json)
+    });
+  }
+
+  private url(path: string): string {
+    return `${this.baseUrl}/${path.replace(/^\//, '')}`;
+  }
+
+  private refreshAccessTokenOnce(): Promise<string> {
+    if (!this.refreshPromise) {
+      const refreshPromise = Promise.resolve().then(() => this.authController.refreshAccessToken());
+      this.refreshPromise = refreshPromise;
+      refreshPromise.then(
+        () => {
+          if (this.refreshPromise === refreshPromise) {
+            this.refreshPromise = null;
+          }
+        },
+        () => {
+          if (this.refreshPromise === refreshPromise) {
+            this.refreshPromise = null;
+          }
+        }
+      );
+    }
+    return this.refreshPromise;
+  }
+
+  private async throwAuthenticationFailure(
+    response: Response,
+    attemptedAuthentication: AuthenticationSnapshot
+  ): Promise<never> {
+    const error = await responseError(response);
+    const currentAuthentication = this.authController.getAuthenticationSnapshot();
+    if (!sameIdentity(attemptedAuthentication, currentAuthentication)) {
+      throw new AuthenticationSupersededError();
+    }
+    if (sameAuthentication(
+      attemptedAuthentication,
+      currentAuthentication
+    )) {
+      this.authController.onAuthenticationFailure(error);
+    }
+    throw error;
+  }
+
+  private assertCurrentIdentity(initialAuthentication: AuthenticationSnapshot | null): void {
+    if (!sameIdentity(
+      initialAuthentication,
+      this.authController.getAuthenticationSnapshot()
+    )) {
+      throw new AuthenticationSupersededError();
+    }
+  }
+}
+
+async function responseError(response: Response): Promise<ApiRequestError> {
+  return new ApiRequestError(response.status, await readPayload(response));
+}
+
+async function responsePayload<T>(response: Response): Promise<T> {
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  return (await readPayload(response)) as T;
+}
+
+async function readPayload(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function isApiError(value: unknown): value is ApiError {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as Partial<ApiError>;
+  return typeof candidate.timestamp === 'string'
+    && Number.isInteger(candidate.status)
+    && typeof candidate.code === 'string'
+    && typeof candidate.message === 'string'
+    && (candidate.requestId === undefined
+      || candidate.requestId === null
+      || typeof candidate.requestId === 'string')
+    && (candidate.fieldErrors === undefined
+      || (Array.isArray(candidate.fieldErrors)
+        && candidate.fieldErrors.every(isApiFieldError)));
+}
+
+function isApiFieldError(value: unknown): boolean {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as { field?: unknown; message?: unknown };
+  return typeof candidate.field === 'string' && typeof candidate.message === 'string';
+}
+
+function sameIdentity(
+  left: AuthenticationSnapshot | null,
+  right: AuthenticationSnapshot | null
+): boolean {
+  return left?.userId === right?.userId && left?.generation === right?.generation;
+}
+
+function sameAuthentication(
+  left: AuthenticationSnapshot | null,
+  right: AuthenticationSnapshot | null
+): boolean {
+  return sameIdentity(left, right) && left?.accessToken === right?.accessToken;
+}

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -1,0 +1,29 @@
+export type UserRole = 'ROLE_USER' | 'ROLE_ADMIN';
+
+export interface UserProfile {
+  id: string;
+  email: string;
+  displayName: string;
+  roles: UserRole[];
+}
+
+export interface AuthResponse {
+  user: UserProfile;
+  accessToken: string;
+  refreshToken: string;
+  expiresInSeconds: number;
+}
+
+export interface ApiFieldError {
+  field: string;
+  message: string;
+}
+
+export interface ApiError {
+  timestamp: string;
+  status: number;
+  code: string;
+  message: string;
+  requestId?: string | null;
+  fieldErrors?: ApiFieldError[];
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { AppProviders } from './app/AppProviders';
 import { AppLayout } from './components/AppLayout';
 import { HomePage } from './pages/HomePage';
 import './styles.css';
@@ -8,11 +9,13 @@ import './styles.css';
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <Routes>
-        <Route element={<AppLayout />}>
-          <Route index element={<HomePage />} />
-        </Route>
-      </Routes>
+      <AppProviders>
+        <Routes>
+          <Route element={<AppLayout />}>
+            <Route index element={<HomePage />} />
+          </Route>
+        </Routes>
+      </AppProviders>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,8 @@
+import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,12 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts'
+  },
   server: {
     port: 5173,
     strictPort: true


### PR DESCRIPTION
## Summary
- add a shared API client, TanStack Query provider, and typed auth context with register, login, logout, and refresh operations
- persist a versioned auth session in localStorage using the JSON-body refresh-token strategy frozen by ADR-007
- bind authenticated requests and session writes to a monotonic auth generation, serialize cross-tab session mutation with Web Locks, and fail closed on stale responses or storage drift
- validate AuthResponse, UserProfile, and API error payloads at runtime before they enter application state
- add frontend test infrastructure and run the frontend suite in GitHub CI

## Why
Issue #24 requires one coherent frontend owner for auth state, token storage, refresh/retry behavior, logout cleanup, and loading/error state before the UI and route-guard batches are implemented.

## Verification
- npm ci
- npm test: 4 files, 39 tests passed
- npm run build
- git diff --check
- exact auth paths, schemas, JSON-body refresh strategy, and VITE_API_BASE_URL were checked against frozen docs and .env.example
- three independent static reviews returned PASS after concurrency, identity-isolation, cache-isolation, and runtime-contract findings were addressed

## Security and correctness review
- logout increments a persisted generation and removes the session immediately, so pre-logout work cannot restore authentication
- login, refresh, and logout coordinate through one same-origin session lock when Web Locks are available
- refresh and revocation waits are bounded with AbortSignal timeouts
- private TanStack Query cache is cleared on logout and account switches
- authenticated responses are rejected when user or generation changes before or during body consumption
- superseded or malformed token responses never replace current state and receive best-effort server revocation

## Scope and limitations
- registration returns UserProfile and intentionally does not create a token session
- login/register pages remain in Issue #25; protected/admin route guards remain in Issue #26
- localStorage is the approved MVP strategy and remains exposed to same-origin JavaScript/XSS as documented in ADR-007
- cross-tab serialization falls back to fail-closed storage reconciliation where Web Locks are unavailable
- npm reports two moderate React Router advisories; the available automated remediation requires a breaking React Router 7 migration, so no force upgrade is included in this batch

## Self-review checklist
- [x] Code is buildable and runnable
- [x] Tests cover success, failure, timeout, malformed payload, account-switch, delayed-response, refresh rotation, and cross-tab races
- [x] Build and IDE artifacts remain excluded
- [x] Commit history is clean and meaningful
- [x] Diff stays within Issue #24 and does not implement Issue #25 or #26

## Stack
- Base branch: feature/23-user-profile-endpoints
- Prerequisite Draft PR: #35
- Issue: #24