### PR TITLE
[Feature] Add login and registration UI

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1,13 +1,16 @@
-import { Outlet } from 'react-router-dom';
+import { Link, NavLink, Outlet } from 'react-router-dom';
 
 export function AppLayout() {
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
       <header className="border-b border-slate-800 bg-slate-950/95">
         <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-          <div className="text-base font-semibold tracking-normal">VoD Platform</div>
-          <nav aria-label="Primary navigation" className="text-sm text-slate-400">
-            <span>Routing placeholder</span>
+          <Link className="text-base font-semibold tracking-normal text-white" to="/">
+            VoD Platform
+          </Link>
+          <nav aria-label="Primary navigation" className="flex items-center gap-4 text-sm">
+            <NavLink className={navLinkClass} to="/login">Sign in</NavLink>
+            <NavLink className={navLinkClass} to="/register">Register</NavLink>
           </nav>
         </div>
       </header>
@@ -16,4 +19,8 @@ export function AppLayout() {
       </main>
     </div>
   );
+}
+
+function navLinkClass({ isActive }: { isActive: boolean }) {
+  return isActive ? 'font-medium text-sky-300' : 'text-slate-400 hover:text-slate-200';
 }

--- a/frontend/src/features/auth/AuthPages.test.tsx
+++ b/frontend/src/features/auth/AuthPages.test.tsx
@@ -1,0 +1,238 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useLocation
+} from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LoginPage } from './pages/LoginPage';
+import { RegisterPage } from './pages/RegisterPage';
+import { AuthProvider } from './AuthContext';
+import { createAuthSession, writeAuthSession } from './authStorage';
+import type { AuthResponse, UserProfile } from '../../lib/api/types';
+
+const user: UserProfile = {
+  id: '3fcf25c2-f096-4462-ae63-4ba4702a9078',
+  email: 'viewer@example.com',
+  displayName: 'Viewer',
+  roles: ['ROLE_USER']
+};
+
+const authResponse: AuthResponse = {
+  user,
+  accessToken: 'access-token',
+  refreshToken: 'refresh-token',
+  expiresInSeconds: 900
+};
+
+describe('LoginPage', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('validates fields before sending a login request', async () => {
+    renderAuthRoutes('/login');
+
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'invalid' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    expect(await screen.findByText('Enter a valid email address.')).toHaveAttribute('role', 'alert');
+    expect(screen.getByText('Password is required.')).toHaveAttribute('role', 'alert');
+    expect(screen.getByLabelText('Email')).toHaveAttribute('aria-invalid', 'true');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('shows loading state and redirects to a safe intended route after login', async () => {
+    let resolveLogin: ((response: Response) => void) | undefined;
+    fetchMock.mockReturnValue(new Promise<Response>((resolve) => {
+      resolveLogin = resolve;
+    }));
+    renderAuthRoutes({ pathname: '/login', state: { from: '/library?tab=recent#latest' } });
+    fillLoginForm();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+    expect(await screen.findByRole('status')).toHaveTextContent('Signing in');
+    expect(screen.getByRole('button', { name: 'Signing in…' })).toBeDisabled();
+    resolveLogin?.(jsonResponse(authResponse));
+
+    expect(await screen.findByText('/library?tab=recent#latest')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith('/api/v1/auth/login', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ email: 'viewer@example.com', password: 'strong-password' })
+    }));
+  });
+
+  it('falls back to home for an unsafe redirect and shows generic server errors', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(apiError(401, 'INVALID_CREDENTIALS', 'Invalid email or password'), 401))
+      .mockResolvedValueOnce(jsonResponse(authResponse));
+    const view = renderAuthRoutes({ pathname: '/login', state: { from: '//evil.example' } });
+    fillLoginForm();
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    expect(await screen.findByText('Invalid email or password')).toHaveAttribute('role', 'alert');
+
+    view.unmount();
+    renderAuthRoutes({ pathname: '/login', state: { from: '//evil.example' } });
+    fillLoginForm();
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+    expect(await screen.findByText('/')).toBeInTheDocument();
+  });
+
+  it('uses accessible labels and login autocomplete values', () => {
+    renderAuthRoutes('/login');
+
+    expect(screen.getByLabelText('Email')).toHaveAttribute('autocomplete', 'email');
+    expect(screen.getByLabelText('Password')).toHaveAttribute('autocomplete', 'current-password');
+    expect(screen.getByRole('link', { name: 'Create an account' })).toHaveAttribute('href', '/register');
+  });
+
+  it('does not label the login form as submitting during a bootstrap refresh', async () => {
+    writeAuthSession({
+      ...createAuthSession(authResponse),
+      accessTokenExpiresAt: Date.now() + 1_000
+    }, window.localStorage);
+    fetchMock.mockReturnValue(new Promise<Response>(() => undefined));
+    renderAuthRoutes('/login');
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeEnabled();
+    expect(screen.getByRole('status')).toHaveTextContent('');
+  });
+});
+
+describe('RegisterPage', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('validates registration boundaries before sending a request', async () => {
+    renderAuthRoutes('/register');
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'viewer@example.com' } });
+    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'V' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: '1234567' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    expect(await screen.findByText('Display name must be at least 2 characters.')).toBeInTheDocument();
+    expect(screen.getByText('Password must be at least 8 characters.')).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('submits displayName and reports success without creating an auth session', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(user, 201));
+    renderAuthRoutes('/register');
+    fillRegistrationForm();
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    await waitFor(() => expect(screen.getByRole('status'))
+      .toHaveTextContent('Account created for viewer@example.com.'));
+    expect(screen.getByRole('link', { name: 'Sign in' })).toHaveAttribute('href', '/login');
+    expect(window.localStorage.length).toBe(0);
+    expect(fetchMock).toHaveBeenCalledWith('/api/v1/auth/register', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({
+        email: 'viewer@example.com',
+        password: 'strong-password',
+        displayName: 'Viewer'
+      })
+    }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create another account' }));
+    expect(screen.getByLabelText('Email')).toHaveValue('');
+    expect(screen.getByLabelText('Display name')).toHaveValue('');
+    expect(screen.getByLabelText('Password')).toHaveValue('');
+  });
+
+  it('maps backend validation errors and duplicate-email errors', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      ...apiError(400, 'VALIDATION_ERROR', 'Request validation failed'),
+      fieldErrors: [{ field: 'displayName', message: 'must be unique for this test' }]
+    }, 400));
+    renderAuthRoutes('/register');
+    fillRegistrationForm();
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+    expect(await screen.findByText('must be unique for this test')).toHaveAttribute('role', 'alert');
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(
+      apiError(409, 'EMAIL_ALREADY_EXISTS', 'An account with this email already exists'),
+      409
+    ));
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+    expect(await screen.findByText('An account with this email already exists')).toHaveAttribute('role', 'alert');
+  });
+
+  it('shows pending state and registration autocomplete values', async () => {
+    fetchMock.mockReturnValue(new Promise<Response>(() => undefined));
+    renderAuthRoutes('/register');
+
+    expect(screen.getByLabelText('Email')).toHaveAttribute('autocomplete', 'email');
+    expect(screen.getByLabelText('Display name')).toHaveAttribute('autocomplete', 'name');
+    expect(screen.getByLabelText('Password')).toHaveAttribute('autocomplete', 'new-password');
+    fillRegistrationForm();
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+    expect(await screen.findByRole('status')).toHaveTextContent('Creating account');
+    expect(screen.getByRole('button', { name: 'Creating account…' })).toBeDisabled();
+  });
+});
+
+function renderAuthRoutes(initialEntry: string | { pathname: string; state?: unknown }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider redirectToLogin={vi.fn()}>
+          <Routes>
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/register" element={<RegisterPage />} />
+            <Route path="*" element={<LocationProbe />} />
+          </Routes>
+        </AuthProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div>{`${location.pathname}${location.search}${location.hash}`}</div>;
+}
+
+function fillLoginForm() {
+  fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'viewer@example.com' } });
+  fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'strong-password' } });
+}
+
+function fillRegistrationForm() {
+  fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'viewer@example.com' } });
+  fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Viewer' } });
+  fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'strong-password' } });
+}
+
+function apiError(status: number, code: string, message: string) {
+  return { timestamp: '2026-08-21T00:00:00Z', status, code, message };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}

--- a/frontend/src/features/auth/authForm.test.ts
+++ b/frontend/src/features/auth/authForm.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { ApiRequestError } from '../../lib/api/client';
+import {
+  authFormFailure,
+  resolvePostLoginPath,
+  validateLoginForm,
+  validateRegistrationForm
+} from './authForm';
+
+describe('auth form validation', () => {
+  it('matches the login request constraints', () => {
+    const maximumDomain = Array.from({ length: 4 }, () => 'a'.repeat(63)).join('.');
+    expect(validateLoginForm({ email: '', password: '   ' })).toEqual({
+      email: 'Email is required.',
+      password: 'Password is required.'
+    });
+    expect(validateLoginForm({ email: 'not-an-email', password: 'valid' })).toEqual({
+      email: 'Enter a valid email address.'
+    });
+    expect(validateLoginForm({ email: `${'a'.repeat(64)}@${maximumDomain}`, password: 'valid' }))
+      .toEqual({});
+    expect(validateLoginForm({ email: `${'a'.repeat(65)}@${maximumDomain}`, password: 'valid' })).toEqual({
+      email: 'Email must be 320 characters or fewer.'
+    });
+  });
+
+  it.each([
+    '.viewer@example.com',
+    'viewer..name@example.com',
+    'viewer@-example.com',
+    'viewer@example.com.',
+    `${'a'.repeat(65)}@example.com`
+  ])('rejects %s consistently for login and registration', (email) => {
+    expect(validateLoginForm({ email, password: 'valid' })).toEqual({
+      email: 'Enter a valid email address.'
+    });
+    expect(validateRegistrationForm({
+      email,
+      password: 'valid-password',
+      displayName: 'Viewer'
+    })).toEqual({ email: 'Enter a valid email address.' });
+  });
+
+  it.each([
+    'viewer@example',
+    'viewer.name+vod@example.com',
+    '"viewer name"@example.com',
+    'viewer@[127.0.0.1]'
+  ])('accepts backend-supported address %s', (email) => {
+    expect(validateLoginForm({ email, password: 'valid' })).toEqual({});
+  });
+
+  it('matches the registration password and displayName boundaries', () => {
+    expect(validateRegistrationForm({
+      email: 'viewer@example.com',
+      password: '1234567',
+      displayName: 'V'
+    })).toEqual({
+      password: 'Password must be at least 8 characters.',
+      displayName: 'Display name must be at least 2 characters.'
+    });
+    expect(validateRegistrationForm({
+      email: 'viewer@example.com',
+      password: 'x'.repeat(72),
+      displayName: 'x'.repeat(100)
+    })).toEqual({});
+    expect(validateRegistrationForm({
+      email: 'viewer@example.com',
+      password: 'x'.repeat(73),
+      displayName: 'x'.repeat(101)
+    })).toEqual({
+      password: 'Password must be 72 characters or fewer.',
+      displayName: 'Display name must be 100 characters or fewer.'
+    });
+  });
+
+  it('preserves recognized backend field errors and a safe summary', () => {
+    const failure = authFormFailure(new ApiRequestError(400, {
+      timestamp: '2026-08-21T00:00:00Z',
+      status: 400,
+      code: 'VALIDATION_ERROR',
+      message: 'Request validation failed',
+      fieldErrors: [
+        { field: 'email', message: 'must be a well-formed email address' },
+        { field: 'unknown', message: 'must not be shown as a field error' }
+      ]
+    }), ['email', 'password']);
+
+    expect(failure).toEqual({
+      message: 'Request validation failed',
+      fieldErrors: { email: 'must be a well-formed email address' }
+    });
+  });
+});
+
+describe('post-login redirect validation', () => {
+  it.each([
+    [{ from: '/library?tab=recent#video' }, '/library?tab=recent#video'],
+    [{ from: { pathname: '/library', search: '?tab=recent', hash: '#video' } }, '/library?tab=recent#video'],
+    [{ from: '//evil.example/path' }, '/'],
+    [{ from: '/\\evil.example/path' }, '/'],
+    [{ from: 'https://evil.example/path' }, '/'],
+    [{ from: '/login' }, '/'],
+    [{ from: '/REGISTER' }, '/'],
+    [{ from: '/register?next=/library' }, '/'],
+    [{ from: 42 }, '/'],
+    [undefined, '/']
+  ])('maps %j to %s', (state, expected) => {
+    expect(resolvePostLoginPath(state)).toBe(expected);
+  });
+});

--- a/frontend/src/features/auth/authForm.ts
+++ b/frontend/src/features/auth/authForm.ts
@@ -1,0 +1,236 @@
+import { ApiRequestError } from '../../lib/api/client';
+import type { LoginRequest, RegisterRequest } from './authApi';
+
+export type AuthFieldErrors<Field extends string> = Partial<Record<Field, string>>;
+
+export interface AuthFormFailure<Field extends string> {
+  message: string;
+  fieldErrors: AuthFieldErrors<Field>;
+}
+
+type LoginField = keyof LoginRequest;
+type RegistrationField = keyof RegisterRequest;
+
+const EMAIL_MAX_LENGTH = 320;
+const PASSWORD_MIN_LENGTH = 8;
+const PASSWORD_MAX_LENGTH = 72;
+const DISPLAY_NAME_MIN_LENGTH = 2;
+const DISPLAY_NAME_MAX_LENGTH = 100;
+const EMAIL_LOCAL_ATOM_PATTERN = /^[a-z0-9!#$%&'*+/=?^_`{|}~\u0080-\uFFFF-]+$/i;
+const EMAIL_QUOTED_ATOM_PATTERN = /^[a-z0-9!#$%&'*.(),<>\[\]:; @+/=?^_`{|}~\u0080-\uFFFF-]$/i;
+const EMAIL_DOMAIN_ATOM_PATTERN = /^[a-z0-9!#$%&'*+/=?^_`{|}~\u0080-\uFFFF-]$/i;
+const IPV4_DOMAIN_PATTERN = /^\[[0-9]{1,3}(?:\.[0-9]{1,3}){3}\]$/;
+
+export function validateLoginForm(request: LoginRequest): AuthFieldErrors<LoginField> {
+  const errors: AuthFieldErrors<LoginField> = {};
+  validateEmail(request.email, errors);
+  if (request.password.trim().length === 0) {
+    errors.password = 'Password is required.';
+  }
+  return errors;
+}
+
+export function validateRegistrationForm(
+  request: RegisterRequest
+): AuthFieldErrors<RegistrationField> {
+  const errors: AuthFieldErrors<RegistrationField> = {};
+  validateEmail(request.email, errors);
+
+  if (request.password.trim().length === 0) {
+    errors.password = 'Password is required.';
+  } else if (request.password.length < PASSWORD_MIN_LENGTH) {
+    errors.password = `Password must be at least ${PASSWORD_MIN_LENGTH} characters.`;
+  } else if (request.password.length > PASSWORD_MAX_LENGTH) {
+    errors.password = `Password must be ${PASSWORD_MAX_LENGTH} characters or fewer.`;
+  }
+
+  if (request.displayName.trim().length === 0) {
+    errors.displayName = 'Display name is required.';
+  } else if (request.displayName.length < DISPLAY_NAME_MIN_LENGTH) {
+    errors.displayName = `Display name must be at least ${DISPLAY_NAME_MIN_LENGTH} characters.`;
+  } else if (request.displayName.length > DISPLAY_NAME_MAX_LENGTH) {
+    errors.displayName = `Display name must be ${DISPLAY_NAME_MAX_LENGTH} characters or fewer.`;
+  }
+  return errors;
+}
+
+export function authFormFailure<Field extends string>(
+  failure: unknown,
+  allowedFields: readonly Field[]
+): AuthFormFailure<Field> {
+  if (!(failure instanceof ApiRequestError) || !failure.apiError) {
+    return {
+      message: 'We could not complete the request. Please try again.',
+      fieldErrors: {}
+    };
+  }
+
+  const allowed = new Set<string>(allowedFields);
+  const fieldErrors: AuthFieldErrors<Field> = {};
+  for (const fieldError of failure.apiError.fieldErrors ?? []) {
+    if (allowed.has(fieldError.field) && fieldErrors[fieldError.field as Field] === undefined) {
+      fieldErrors[fieldError.field as Field] = fieldError.message;
+    }
+  }
+  return { message: failure.apiError.message, fieldErrors };
+}
+
+export function resolvePostLoginPath(state: unknown): string {
+  if (!state || typeof state !== 'object' || !('from' in state)) {
+    return '/';
+  }
+  const from = (state as { from?: unknown }).from;
+  if (typeof from === 'string') {
+    return safeInternalPath(from);
+  }
+  if (!from || typeof from !== 'object') {
+    return '/';
+  }
+
+  const candidate = from as { pathname?: unknown; search?: unknown; hash?: unknown };
+  if (typeof candidate.pathname !== 'string') {
+    return '/';
+  }
+  const search = typeof candidate.search === 'string' ? candidate.search : '';
+  const hash = typeof candidate.hash === 'string' ? candidate.hash : '';
+  if ((search && !search.startsWith('?')) || (hash && !hash.startsWith('#'))) {
+    return '/';
+  }
+  return safeInternalPath(`${candidate.pathname}${search}${hash}`);
+}
+
+function validateEmail(email: string, errors: { email?: string }): void {
+  if (email.trim().length === 0) {
+    errors.email = 'Email is required.';
+  } else if (email.length > EMAIL_MAX_LENGTH) {
+    errors.email = `Email must be ${EMAIL_MAX_LENGTH} characters or fewer.`;
+  } else if (!isBackendCompatibleEmail(email)) {
+    errors.email = 'Enter a valid email address.';
+  }
+}
+
+function isBackendCompatibleEmail(email: string): boolean {
+  const splitPosition = email.lastIndexOf('@');
+  if (splitPosition < 0) {
+    return false;
+  }
+  const localPart = email.slice(0, splitPosition);
+  const domainPart = email.slice(splitPosition + 1);
+  return localPart.length <= 64
+    && validLocalPart(localPart)
+    && validEmailDomain(domainPart);
+}
+
+function validLocalPart(localPart: string): boolean {
+  const segments: string[] = [];
+  let current = '';
+  let quoted = false;
+  let escaped = false;
+  for (const character of localPart) {
+    if (escaped) {
+      current += `\\${character}`;
+      escaped = false;
+    } else if (quoted && character === '\\') {
+      escaped = true;
+    } else if (character === '"') {
+      quoted = !quoted;
+      current += character;
+    } else if (character === '.' && !quoted) {
+      segments.push(current);
+      current = '';
+    } else {
+      current += character;
+    }
+  }
+  if (quoted || escaped) {
+    return false;
+  }
+  segments.push(current);
+  return segments.every(validLocalSegment);
+}
+
+function validLocalSegment(segment: string): boolean {
+  if (EMAIL_LOCAL_ATOM_PATTERN.test(segment)) {
+    return true;
+  }
+  if (segment.length < 3 || !segment.startsWith('"') || !segment.endsWith('"')) {
+    return false;
+  }
+  const inside = segment.slice(1, -1);
+  if (inside.length === 0) {
+    return false;
+  }
+  for (let index = 0; index < inside.length; index += 1) {
+    const character = inside[index];
+    if (character === '\\') {
+      index += 1;
+      if (inside[index] !== '\\' && inside[index] !== '"') {
+        return false;
+      }
+    } else if (!EMAIL_QUOTED_ATOM_PATTERN.test(character) || character === '"') {
+      return false;
+    }
+  }
+  return true;
+}
+
+function validEmailDomain(domain: string): boolean {
+  if (domain.endsWith('.') || domain.length === 0) {
+    return false;
+  }
+  if (IPV4_DOMAIN_PATTERN.test(domain)) {
+    return true;
+  }
+  if (/^\[IPv6:.+\]$/i.test(domain)) {
+    return validIpv6Address(domain.slice(6, -1));
+  }
+
+  const labels = domain.split('.');
+  if (!labels.every(validDomainLabel)) {
+    return false;
+  }
+  if (/^[\u0000-\u007f]+$/.test(domain)) {
+    return domain.length <= 255 && labels.every((label) => label.length <= 63);
+  }
+  try {
+    const asciiDomain = new URL(`http://${domain}`).hostname;
+    return asciiDomain.length <= 255
+      && asciiDomain.split('.').every((label) => label.length <= 63);
+  } catch {
+    return false;
+  }
+}
+
+function validDomainLabel(label: string): boolean {
+  if (label.length === 0 || label.startsWith('-') || label.endsWith('-')) {
+    return false;
+  }
+  return [...label].every(
+    (character) => character === '-' || EMAIL_DOMAIN_ATOM_PATTERN.test(character)
+  );
+}
+
+function validIpv6Address(address: string): boolean {
+  const addressWithoutZone = /^fe80:/i.test(address)
+    ? address.replace(/%[0-9a-z]+$/i, '')
+    : address;
+  try {
+    return new URL(`http://[${addressWithoutZone}]`).hostname.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function safeInternalPath(path: string): string {
+  if (!path.startsWith('/')
+    || path.startsWith('//')
+    || /[\\\u0000-\u001f\u007f]/.test(path)) {
+    return '/';
+  }
+  const pathname = path.split(/[?#]/, 1)[0].replace(/\/+$/, '') || '/';
+  const normalizedPathname = pathname.toLowerCase();
+  if (normalizedPathname === '/login' || normalizedPathname === '/register') {
+    return '/';
+  }
+  return path;
+}

--- a/frontend/src/features/auth/components/AuthFormCard.tsx
+++ b/frontend/src/features/auth/components/AuthFormCard.tsx
@@ -1,0 +1,110 @@
+import type { InputHTMLAttributes, PropsWithChildren } from 'react';
+import { Link } from 'react-router-dom';
+
+interface AuthFormCardProps extends PropsWithChildren {
+  title: string;
+  description: string;
+  alternateText: string;
+  alternateLinkText: string;
+  alternateTo: string;
+}
+
+export function AuthFormCard({
+  title,
+  description,
+  alternateText,
+  alternateLinkText,
+  alternateTo,
+  children
+}: AuthFormCardProps) {
+  return (
+    <section className="mx-auto w-full max-w-md rounded-lg border border-slate-800 bg-slate-900 p-6 shadow-xl shadow-black/20 sm:p-8">
+      <h1 className="text-2xl font-semibold text-white">{title}</h1>
+      <p className="mt-2 text-sm leading-6 text-slate-300">{description}</p>
+      <div className="mt-6">{children}</div>
+      <p className="mt-6 text-center text-sm text-slate-400">
+        {alternateText}{' '}
+        <Link className="font-medium text-sky-400 hover:text-sky-300" to={alternateTo}>
+          {alternateLinkText}
+        </Link>
+      </p>
+    </section>
+  );
+}
+
+interface AuthFieldProps extends InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+  name: string;
+  error?: string;
+}
+
+export function AuthField({ label, name, error, className, ...inputProps }: AuthFieldProps) {
+  const inputId = `auth-${name}`;
+  const errorId = `${inputId}-error`;
+  return (
+    <div>
+      <label className="block text-sm font-medium text-slate-200" htmlFor={inputId}>
+        {label}
+      </label>
+      <input
+        {...inputProps}
+        aria-describedby={error ? errorId : undefined}
+        aria-invalid={error ? 'true' : 'false'}
+        className={`mt-2 block w-full rounded-md border bg-slate-950 px-3 py-2 text-sm text-white outline-none transition placeholder:text-slate-600 focus:ring-2 ${
+          error
+            ? 'border-rose-500 focus:border-rose-400 focus:ring-rose-500/30'
+            : 'border-slate-700 focus:border-sky-500 focus:ring-sky-500/30'
+        } ${className ?? ''}`}
+        id={inputId}
+        name={name}
+      />
+      {error ? (
+        <p className="mt-2 text-sm text-rose-300" id={errorId} role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+interface SubmitButtonProps {
+  idleLabel: string;
+  loadingLabel: string;
+  loadingStatusLabel: string;
+  loading: boolean;
+}
+
+export function SubmitButton({
+  idleLabel,
+  loadingLabel,
+  loadingStatusLabel,
+  loading
+}: SubmitButtonProps) {
+  return (
+    <>
+      <button
+        className="flex w-full items-center justify-center gap-2 rounded-md bg-sky-500 px-4 py-2.5 text-sm font-semibold text-slate-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-sky-800 disabled:text-slate-300"
+        disabled={loading}
+        type="submit"
+      >
+        {loading ? (
+          <>
+            <svg
+              aria-hidden="true"
+              className="h-4 w-4 animate-spin"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" d="M4 12a8 8 0 018-8" stroke="currentColor" strokeLinecap="round" strokeWidth="4" />
+            </svg>
+            {loadingLabel}
+          </>
+        ) : idleLabel}
+      </button>
+      <span aria-live="polite" className="sr-only" role="status">
+        {loading ? loadingStatusLabel : ''}
+      </span>
+    </>
+  );
+}

--- a/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/frontend/src/features/auth/pages/LoginPage.tsx
@@ -1,0 +1,107 @@
+import { type FormEvent, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from '../AuthContext';
+import type { LoginRequest } from '../authApi';
+import {
+  authFormFailure,
+  type AuthFieldErrors,
+  resolvePostLoginPath,
+  validateLoginForm
+} from '../authForm';
+import { AuthField, AuthFormCard, SubmitButton } from '../components/AuthFormCard';
+
+type LoginField = keyof LoginRequest;
+
+const LOGIN_FIELDS: readonly LoginField[] = ['email', 'password'];
+const INITIAL_VALUES: LoginRequest = { email: '', password: '' };
+
+export function LoginPage() {
+  const { login, clearError } = useAuth();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [values, setValues] = useState(INITIAL_VALUES);
+  const [fieldErrors, setFieldErrors] = useState<AuthFieldErrors<LoginField>>({});
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const submitInFlight = useRef(false);
+
+  const updateField = (field: LoginField, value: string) => {
+    setValues((current) => ({ ...current, [field]: value }));
+    setFieldErrors((current) => ({ ...current, [field]: undefined }));
+    setServerError(null);
+    clearError();
+  };
+
+  const submit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (submitInFlight.current) {
+      return;
+    }
+    const validationErrors = validateLoginForm(values);
+    setFieldErrors(validationErrors);
+    setServerError(null);
+    clearError();
+    if (Object.keys(validationErrors).length > 0) {
+      return;
+    }
+
+    submitInFlight.current = true;
+    setIsSubmitting(true);
+    try {
+      await login(values);
+      navigate(resolvePostLoginPath(location.state), { replace: true });
+    } catch (failure) {
+      const formFailure = authFormFailure(failure, LOGIN_FIELDS);
+      setFieldErrors(formFailure.fieldErrors);
+      setServerError(formFailure.message);
+    } finally {
+      submitInFlight.current = false;
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <AuthFormCard
+      alternateLinkText="Create an account"
+      alternateText="New to VoD Platform?"
+      alternateTo="/register"
+      description="Use your account credentials to continue."
+      title="Sign in"
+    >
+      <form aria-busy={isSubmitting} className="grid gap-5" noValidate onSubmit={submit}>
+        {serverError ? (
+          <p className="rounded-md border border-rose-500/50 bg-rose-500/10 p-3 text-sm text-rose-200" role="alert">
+            {serverError}
+          </p>
+        ) : null}
+        <AuthField
+          autoComplete="email"
+          error={fieldErrors.email}
+          label="Email"
+          maxLength={320}
+          name="email"
+          onChange={(event) => updateField('email', event.target.value)}
+          required
+          type="email"
+          value={values.email}
+        />
+        <AuthField
+          autoComplete="current-password"
+          error={fieldErrors.password}
+          label="Password"
+          name="password"
+          onChange={(event) => updateField('password', event.target.value)}
+          required
+          type="password"
+          value={values.password}
+        />
+        <SubmitButton
+          idleLabel="Sign in"
+          loading={isSubmitting}
+          loadingLabel="Signing in…"
+          loadingStatusLabel="Signing in"
+        />
+      </form>
+    </AuthFormCard>
+  );
+}

--- a/frontend/src/features/auth/pages/RegisterPage.tsx
+++ b/frontend/src/features/auth/pages/RegisterPage.tsx
@@ -1,0 +1,152 @@
+import { type FormEvent, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import type { UserProfile } from '../../../lib/api/types';
+import { useAuth } from '../AuthContext';
+import type { RegisterRequest } from '../authApi';
+import {
+  authFormFailure,
+  type AuthFieldErrors,
+  validateRegistrationForm
+} from '../authForm';
+import { AuthField, AuthFormCard, SubmitButton } from '../components/AuthFormCard';
+
+type RegistrationField = keyof RegisterRequest;
+
+const REGISTRATION_FIELDS: readonly RegistrationField[] = ['email', 'password', 'displayName'];
+const INITIAL_VALUES: RegisterRequest = { email: '', password: '', displayName: '' };
+
+export function RegisterPage() {
+  const { register, clearError } = useAuth();
+  const [values, setValues] = useState(INITIAL_VALUES);
+  const [fieldErrors, setFieldErrors] = useState<AuthFieldErrors<RegistrationField>>({});
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [registeredUser, setRegisteredUser] = useState<UserProfile | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const submitInFlight = useRef(false);
+
+  const updateField = (field: RegistrationField, value: string) => {
+    setValues((current) => ({ ...current, [field]: value }));
+    setFieldErrors((current) => ({ ...current, [field]: undefined }));
+    setServerError(null);
+    clearError();
+  };
+
+  const submit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (submitInFlight.current) {
+      return;
+    }
+    const validationErrors = validateRegistrationForm(values);
+    setFieldErrors(validationErrors);
+    setServerError(null);
+    clearError();
+    if (Object.keys(validationErrors).length > 0) {
+      return;
+    }
+
+    submitInFlight.current = true;
+    setIsSubmitting(true);
+    try {
+      const profile = await register(values);
+      setValues(INITIAL_VALUES);
+      setRegisteredUser(profile);
+    } catch (failure) {
+      const formFailure = authFormFailure(failure, REGISTRATION_FIELDS);
+      setFieldErrors(formFailure.fieldErrors);
+      setServerError(formFailure.message);
+    } finally {
+      submitInFlight.current = false;
+      setIsSubmitting(false);
+    }
+  };
+
+  if (registeredUser) {
+    return (
+      <section className="mx-auto w-full max-w-md rounded-lg border border-emerald-700 bg-emerald-950/40 p-8 text-center">
+        <div aria-hidden="true" className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-emerald-500/20 text-2xl text-emerald-300">
+          ✓
+        </div>
+        <h1 className="mt-4 text-2xl font-semibold text-white">Account created</h1>
+        <p
+          className="mt-3 text-sm leading-6 text-emerald-100"
+          role="status"
+        >
+          Account created for {registeredUser.email}.
+        </p>
+        <p className="mt-2 text-sm text-slate-300">Sign in to start your session.</p>
+        <Link
+          className="mt-6 inline-flex rounded-md bg-sky-500 px-4 py-2.5 text-sm font-semibold text-slate-950 hover:bg-sky-400"
+          to="/login"
+        >
+          Sign in
+        </Link>
+        <button
+          className="mt-4 block w-full text-sm font-medium text-slate-300 hover:text-white"
+          onClick={() => setRegisteredUser(null)}
+          type="button"
+        >
+          Create another account
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <AuthFormCard
+      alternateLinkText="Sign in"
+      alternateText="Already have an account?"
+      alternateTo="/login"
+      description="Create a viewer account. You will sign in after registration."
+      title="Create account"
+    >
+      <form aria-busy={isSubmitting} className="grid gap-5" noValidate onSubmit={submit}>
+        {serverError ? (
+          <p className="rounded-md border border-rose-500/50 bg-rose-500/10 p-3 text-sm text-rose-200" role="alert">
+            {serverError}
+          </p>
+        ) : null}
+        <AuthField
+          autoComplete="email"
+          error={fieldErrors.email}
+          label="Email"
+          maxLength={320}
+          name="email"
+          onChange={(event) => updateField('email', event.target.value)}
+          required
+          type="email"
+          value={values.email}
+        />
+        <AuthField
+          autoComplete="name"
+          error={fieldErrors.displayName}
+          label="Display name"
+          maxLength={100}
+          minLength={2}
+          name="displayName"
+          onChange={(event) => updateField('displayName', event.target.value)}
+          required
+          type="text"
+          value={values.displayName}
+        />
+        <AuthField
+          autoComplete="new-password"
+          error={fieldErrors.password}
+          label="Password"
+          maxLength={72}
+          minLength={8}
+          name="password"
+          onChange={(event) => updateField('password', event.target.value)}
+          required
+          type="password"
+          value={values.password}
+        />
+        <SubmitButton
+          idleLabel="Create account"
+          loading={isSubmitting}
+          loadingLabel="Creating account…"
+          loadingStatusLabel="Creating account"
+        />
+      </form>
+    </AuthFormCard>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { AppProviders } from './app/AppProviders';
 import { AppLayout } from './components/AppLayout';
+import { LoginPage } from './features/auth/pages/LoginPage';
+import { RegisterPage } from './features/auth/pages/RegisterPage';
 import { HomePage } from './pages/HomePage';
 import './styles.css';
 
@@ -13,6 +15,8 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
         <Routes>
           <Route element={<AppLayout />}>
             <Route index element={<HomePage />} />
+            <Route path="login" element={<LoginPage />} />
+            <Route path="register" element={<RegisterPage />} />
           </Route>
         </Routes>
       </AppProviders>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -3,19 +3,19 @@ export function HomePage() {
     <section className="grid gap-6">
       <div className="max-w-3xl">
         <h1 className="text-3xl font-semibold tracking-normal text-white sm:text-4xl">
-          Frontend scaffold is ready
+          Your self-hosted video library
         </h1>
         <p className="mt-4 text-base leading-7 text-slate-300">
-          React, TypeScript, Vite, Tailwind CSS, and a routing placeholder are initialized.
-          Auth, API integration, playback, and admin screens are deferred to later sprint issues.
+          Account registration, sign-in, and shared authentication state are ready.
+          Protected library, playback, and administration screens arrive in later sprint issues.
         </p>
       </div>
       <div className="grid gap-3 rounded border border-slate-800 bg-slate-900 p-5 text-sm text-slate-300">
-        <div className="font-medium text-slate-100">Current scope</div>
+        <div className="font-medium text-slate-100">Current auth scope</div>
         <ul className="grid gap-2">
-          <li>Vite dev server uses port 5173.</li>
-          <li>TypeScript strict mode is enabled.</li>
-          <li>Tailwind CSS is configured.</li>
+          <li>Create an account with your email and display name.</li>
+          <li>Sign in securely and return to your intended app route.</li>
+          <li>Authentication errors stay explicit without exposing credentials.</li>
         </ul>
       </div>
     </section>


### PR DESCRIPTION
## What changed
- add public Login and Register routes with accessible form controls
- validate email, password, and displayName against the backend request constraints
- render request loading, backend field/general errors, and non-authenticating registration success
- safely restore only internal intended routes after successful login
- replace stale scaffold navigation and auth copy
- add focused form, redirect, concurrency, credential-clearing, and API-state tests

## Why
Issue 2.9 requires usable Login and Register screens on top of the shared auth state from Issue 2.8. Registration deliberately consumes UserProfile without issuing or persisting tokens; login delegates all token/session handling to AuthContext.

## Verification
- npm test: 6 files, 70 tests passed
- npm run build: TypeScript and Vite production build passed
- git diff --cached --check: passed
- source identifiers and limits were re-checked against BACKLOG.md, API-CONTRACT.yaml, SECURITY.md, ADR-007, and backend DTO validators
- three read-only final reviews passed for contract, UX/accessibility, and security/concurrency

## Security and scope review
- intended-route input rejects external, protocol-relative, backslash/control-character, and auth-loop destinations
- known backend field errors are allowlisted; unknown failures use a generic user-facing message
- passwords are never persisted and registration form values are cleared immediately on success
- no route guards, admin behavior, refresh logic, or token-storage logic were added in this batch

## Self-review checklist
- [x] Is the code buildable and runnable?
- [x] Are generated build/IDE files excluded?
- [x] Is the commit history clean and meaningful?
- [x] Reviewed correctness, security, accessibility, contract consistency, and Issue 2.9 scope
- [x] Verified this self-review is not a substitute for independent review

## Stack
- base: feature/24-frontend-auth-state (PR #36)
- merge only after PR #36

Closes #25