### PR TITLE
[Feature] Add protected route guards

### DIFF
--- a/frontend/src/app/AppProviders.tsx
+++ b/frontend/src/app/AppProviders.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import type { PropsWithChildren } from 'react';
+import { type PropsWithChildren, useCallback } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { AuthProvider } from '../features/auth/AuthContext';
 
 const queryClient = new QueryClient({
@@ -12,9 +13,21 @@ const queryClient = new QueryClient({
 });
 
 export function AppProviders({ children }: PropsWithChildren) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const redirectToLogin = useCallback(() => {
+    if (location.pathname.toLowerCase() === '/login') {
+      return;
+    }
+    navigate('/login', {
+      replace: true,
+      state: { from: `${location.pathname}${location.search}${location.hash}` }
+    });
+  }, [location.hash, location.pathname, location.search, navigate]);
+
   return (
     <QueryClientProvider client={queryClient}>
-      <AuthProvider>{children}</AuthProvider>
+      <AuthProvider redirectToLogin={redirectToLogin}>{children}</AuthProvider>
     </QueryClientProvider>
   );
 }

--- a/frontend/src/app/AppRoutes.test.tsx
+++ b/frontend/src/app/AppRoutes.test.tsx
@@ -1,0 +1,136 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthResponse, UserProfile } from '../lib/api/types';
+import { AuthProvider } from '../features/auth/AuthContext';
+import { createAuthSession, writeAuthSession } from '../features/auth/authStorage';
+import { AppRoutes } from './AppRoutes';
+import { AppProviders } from './AppProviders';
+
+const regularUser: UserProfile = {
+  id: '3fcf25c2-f096-4462-ae63-4ba4702a9078',
+  email: 'viewer@example.com',
+  displayName: 'Viewer',
+  roles: ['ROLE_USER']
+};
+
+describe('AppRoutes guard wiring', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('sends a guest from /account to the login page', async () => {
+    renderRoutes('/account');
+
+    expect(await screen.findByRole('heading', { name: 'Sign in' })).toBeInTheDocument();
+  });
+
+  it('sends a regular user from /admin to the forbidden page', async () => {
+    persistUser(regularUser);
+    renderRoutes('/admin');
+
+    expect(await screen.findByRole('heading', { name: 'Access forbidden' })).toBeInTheDocument();
+  });
+
+  it('renders /admin for ROLE_ADMIN', async () => {
+    persistUser({ ...regularUser, roles: ['ROLE_USER', 'ROLE_ADMIN'] });
+    renderRoutes('/admin');
+
+    expect(await screen.findByRole('heading', { name: 'Administration' })).toBeInTheDocument();
+  });
+
+  it('preserves the intended route when bootstrap refresh fails before login', async () => {
+    persistUser(regularUser, Date.now() + 1_000);
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({
+        timestamp: '2026-08-21T00:00:00Z',
+        status: 401,
+        code: 'INVALID_REFRESH_TOKEN',
+        message: 'Refresh token is invalid or expired'
+      }, 401))
+      .mockResolvedValueOnce(jsonResponse({
+        user: regularUser,
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+        expiresInSeconds: 900
+      }));
+    renderProductionRoutes('/account?tab=security#sessions');
+
+    await screen.findByRole('heading', { name: 'Sign in' });
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'viewer@example.com' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'strong-password' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    await waitFor(() => expect(screen.getByTestId('current-location'))
+      .toHaveTextContent('/account?tab=security#sessions'));
+    expect(screen.getByRole('heading', { name: 'Account' })).toBeInTheDocument();
+  });
+});
+
+function renderRoutes(initialEntry: string) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+      initialEntries={[initialEntry]}
+    >
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider redirectToLogin={vi.fn()}>
+          <AppRoutes />
+        </AuthProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+function renderProductionRoutes(initialEntry: string) {
+  return render(
+    <MemoryRouter
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+      initialEntries={[initialEntry]}
+    >
+      <AppProviders>
+        <LocationProbe />
+        <AppRoutes />
+      </AppProviders>
+    </MemoryRouter>
+  );
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return (
+    <span className="sr-only" data-testid="current-location">
+      {`${location.pathname}${location.search}${location.hash}`}
+    </span>
+  );
+}
+
+function persistUser(user: UserProfile, accessTokenExpiresAt?: number) {
+  const response: AuthResponse = {
+    user,
+    accessToken: 'access-token',
+    refreshToken: 'refresh-token',
+    expiresInSeconds: 900
+  };
+  writeAuthSession({
+    ...createAuthSession(response),
+    ...(accessTokenExpiresAt === undefined ? {} : { accessTokenExpiresAt })
+  }, window.localStorage);
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}

--- a/frontend/src/app/AppRoutes.tsx
+++ b/frontend/src/app/AppRoutes.tsx
@@ -1,0 +1,26 @@
+import { Route, Routes } from 'react-router-dom';
+import { AppLayout } from '../components/AppLayout';
+import { AdminRoute, ProtectedRoute } from '../features/auth/RouteGuards';
+import { LoginPage } from '../features/auth/pages/LoginPage';
+import { RegisterPage } from '../features/auth/pages/RegisterPage';
+import { AccountPage, AdminPage, ForbiddenPage } from '../pages/AccessPages';
+import { HomePage } from '../pages/HomePage';
+
+export function AppRoutes() {
+  return (
+    <Routes>
+      <Route element={<AppLayout />}>
+        <Route index element={<HomePage />} />
+        <Route path="login" element={<LoginPage />} />
+        <Route path="register" element={<RegisterPage />} />
+        <Route path="forbidden" element={<ForbiddenPage />} />
+        <Route element={<ProtectedRoute />}>
+          <Route path="account" element={<AccountPage />} />
+        </Route>
+        <Route element={<AdminRoute />}>
+          <Route path="admin" element={<AdminPage />} />
+        </Route>
+      </Route>
+    </Routes>
+  );
+}

--- a/frontend/src/components/AppLayout.test.tsx
+++ b/frontend/src/components/AppLayout.test.tsx
@@ -1,0 +1,71 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import type { AuthResponse, UserProfile } from '../lib/api/types';
+import { AuthProvider } from '../features/auth/AuthContext';
+import { createAuthSession, writeAuthSession } from '../features/auth/authStorage';
+import { AppLayout } from './AppLayout';
+
+const regularUser: UserProfile = {
+  id: '3fcf25c2-f096-4462-ae63-4ba4702a9078',
+  email: 'viewer@example.com',
+  displayName: 'Viewer',
+  roles: ['ROLE_USER']
+};
+
+describe('AppLayout auth navigation', () => {
+  it('shows guest links without protected or admin navigation', async () => {
+    renderLayout();
+
+    expect(await screen.findByRole('link', { name: 'Sign in' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Register' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Account' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Admin' })).not.toBeInTheDocument();
+  });
+
+  it('hides admin navigation from a regular authenticated user', async () => {
+    persistUser(regularUser);
+    renderLayout();
+
+    expect(await screen.findByRole('link', { name: 'Account' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Admin' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Sign in' })).not.toBeInTheDocument();
+  });
+
+  it('shows admin navigation only to ROLE_ADMIN', async () => {
+    persistUser({ ...regularUser, roles: ['ROLE_USER', 'ROLE_ADMIN'] });
+    renderLayout();
+
+    expect(await screen.findByRole('link', { name: 'Admin' })).toHaveAttribute('href', '/admin');
+  });
+
+});
+
+function renderLayout() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider redirectToLogin={vi.fn()}>
+          <Routes>
+            <Route element={<AppLayout />}>
+              <Route index element={<div>Home</div>} />
+            </Route>
+          </Routes>
+        </AuthProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+function persistUser(user: UserProfile) {
+  const response: AuthResponse = {
+    user,
+    accessToken: 'access-token',
+    refreshToken: 'refresh-token',
+    expiresInSeconds: 900
+  };
+  writeAuthSession(createAuthSession(response), window.localStorage);
+}

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1,6 +1,10 @@
 import { Link, NavLink, Outlet } from 'react-router-dom';
+import { useAuth } from '../features/auth/AuthContext';
 
 export function AppLayout() {
+  const { isAuthenticated, isInitializing, user } = useAuth();
+  const isAdmin = user?.roles.includes('ROLE_ADMIN') ?? false;
+
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
       <header className="border-b border-slate-800 bg-slate-950/95">
@@ -8,9 +12,23 @@ export function AppLayout() {
           <Link className="text-base font-semibold tracking-normal text-white" to="/">
             VoD Platform
           </Link>
-          <nav aria-label="Primary navigation" className="flex items-center gap-4 text-sm">
-            <NavLink className={navLinkClass} to="/login">Sign in</NavLink>
-            <NavLink className={navLinkClass} to="/register">Register</NavLink>
+          <nav
+            aria-busy={isInitializing}
+            aria-label="Primary navigation"
+            className="flex min-h-5 items-center gap-4 text-sm"
+          >
+            {!isInitializing && isAuthenticated ? (
+              <>
+                <NavLink className={navLinkClass} to="/account">Account</NavLink>
+                {isAdmin ? <NavLink className={navLinkClass} to="/admin">Admin</NavLink> : null}
+              </>
+            ) : null}
+            {!isInitializing && !isAuthenticated ? (
+              <>
+                <NavLink className={navLinkClass} to="/login">Sign in</NavLink>
+                <NavLink className={navLinkClass} to="/register">Register</NavLink>
+              </>
+            ) : null}
           </nav>
         </div>
       </header>

--- a/frontend/src/features/auth/RouteGuards.test.tsx
+++ b/frontend/src/features/auth/RouteGuards.test.tsx
@@ -1,0 +1,140 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { PropsWithChildren, ReactNode } from 'react';
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useLocation
+} from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthResponse, UserProfile } from '../../lib/api/types';
+import { AuthProvider } from './AuthContext';
+import { AdminRoute, ProtectedRoute } from './RouteGuards';
+import { createAuthSession, writeAuthSession } from './authStorage';
+
+const regularUser: UserProfile = {
+  id: '3fcf25c2-f096-4462-ae63-4ba4702a9078',
+  email: 'viewer@example.com',
+  displayName: 'Viewer',
+  roles: ['ROLE_USER']
+};
+
+const authResponse: AuthResponse = {
+  user: regularUser,
+  accessToken: 'access-token',
+  refreshToken: 'refresh-token',
+  expiresInSeconds: 900
+};
+
+describe('route guards', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('redirects an unauthenticated protected route and preserves the intended path', async () => {
+    renderGuardRoutes('/account?tab=security#sessions', <ProtectedRoute />);
+
+    expect(await screen.findByTestId('login-destination')).toHaveTextContent(
+      '/account?tab=security#sessions'
+    );
+    expect(screen.queryByText('Protected content')).not.toBeInTheDocument();
+  });
+
+  it('renders protected content for an authenticated user', async () => {
+    persistSession(authResponse);
+    renderGuardRoutes('/account', <ProtectedRoute />);
+
+    expect(await screen.findByText('Protected content')).toBeInTheDocument();
+  });
+
+  it('does not render or redirect until auth initialization finishes', async () => {
+    persistSession(authResponse, Date.now() + 1_000);
+    fetchMock.mockReturnValue(new Promise<Response>(() => undefined));
+    renderGuardRoutes('/account', <ProtectedRoute />);
+
+    expect(await screen.findByRole('status')).toHaveTextContent('Checking authentication…');
+    expect(screen.queryByText('Protected content')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('login-destination')).not.toBeInTheDocument();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('redirects a regular user away from an admin route', async () => {
+    persistSession(authResponse);
+    renderGuardRoutes('/admin', <AdminRoute />);
+
+    expect(await screen.findByText('Forbidden destination')).toBeInTheDocument();
+    expect(screen.queryByText('Admin content')).not.toBeInTheDocument();
+  });
+
+  it('renders an admin route only for ROLE_ADMIN', async () => {
+    persistSession({
+      ...authResponse,
+      user: { ...regularUser, roles: ['ROLE_USER', 'ROLE_ADMIN'] }
+    });
+    renderGuardRoutes('/admin', <AdminRoute />);
+
+    expect(await screen.findByText('Admin content')).toBeInTheDocument();
+  });
+
+  it('redirects an unauthenticated admin route to login', async () => {
+    renderGuardRoutes('/admin', <AdminRoute />);
+
+    expect(await screen.findByTestId('login-destination')).toHaveTextContent('/admin');
+    expect(screen.queryByText('Admin content')).not.toBeInTheDocument();
+  });
+});
+
+function renderGuardRoutes(initialEntry: string, guard: ReactNode) {
+  return render(
+    <MemoryRouter
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+      initialEntries={[initialEntry]}
+    >
+      <TestProviders>
+        <Routes>
+          <Route element={guard}>
+            <Route path="/account" element={<div>Protected content</div>} />
+            <Route path="/admin" element={<div>Admin content</div>} />
+          </Route>
+          <Route path="/login" element={<LoginDestination />} />
+          <Route path="/forbidden" element={<div>Forbidden destination</div>} />
+        </Routes>
+      </TestProviders>
+    </MemoryRouter>
+  );
+}
+
+function LoginDestination() {
+  const location = useLocation();
+  const from = (location.state as { from?: unknown } | null)?.from;
+  return (
+    <div data-testid="login-destination">
+      Login destination {typeof from === 'string' ? from : ''}
+    </div>
+  );
+}
+
+function TestProviders({ children }: PropsWithChildren) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider redirectToLogin={vi.fn()}>{children}</AuthProvider>
+    </QueryClientProvider>
+  );
+}
+
+function persistSession(response: AuthResponse, accessTokenExpiresAt?: number) {
+  writeAuthSession({
+    ...createAuthSession(response),
+    ...(accessTokenExpiresAt === undefined ? {} : { accessTokenExpiresAt })
+  }, window.localStorage);
+}

--- a/frontend/src/features/auth/RouteGuards.tsx
+++ b/frontend/src/features/auth/RouteGuards.tsx
@@ -1,0 +1,51 @@
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useAuth } from './AuthContext';
+
+const ADMIN_ROLE = 'ROLE_ADMIN';
+
+export function ProtectedRoute() {
+  return <AuthRouteGuard requireAdmin={false} />;
+}
+
+export function AdminRoute() {
+  return <AuthRouteGuard requireAdmin />;
+}
+
+function AuthRouteGuard({ requireAdmin }: { requireAdmin: boolean }) {
+  const { isAuthenticated, isInitializing, user } = useAuth();
+  const location = useLocation();
+
+  if (isInitializing) {
+    return (
+      <div className="flex min-h-48 items-center justify-center" role="status">
+        <span className="inline-flex items-center gap-3 text-sm text-slate-300">
+          <span
+            aria-hidden="true"
+            className="h-4 w-4 animate-spin rounded-full border-2 border-slate-600 border-t-sky-400"
+          />
+          Checking authentication…
+        </span>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <Navigate
+        replace
+        state={{ from: intendedPath(location.pathname, location.search, location.hash) }}
+        to="/login"
+      />
+    );
+  }
+
+  if (requireAdmin && !user?.roles.includes(ADMIN_ROLE)) {
+    return <Navigate replace to="/forbidden" />;
+  }
+
+  return <Outlet />;
+}
+
+function intendedPath(pathname: string, search: string, hash: string): string {
+  return `${pathname}${search}${hash}`;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,24 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 import { AppProviders } from './app/AppProviders';
-import { AppLayout } from './components/AppLayout';
-import { LoginPage } from './features/auth/pages/LoginPage';
-import { RegisterPage } from './features/auth/pages/RegisterPage';
-import { HomePage } from './pages/HomePage';
+import { AppRoutes } from './app/AppRoutes';
 import './styles.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
       <AppProviders>
-        <Routes>
-          <Route element={<AppLayout />}>
-            <Route index element={<HomePage />} />
-            <Route path="login" element={<LoginPage />} />
-            <Route path="register" element={<RegisterPage />} />
-          </Route>
-        </Routes>
+        <AppRoutes />
       </AppProviders>
     </BrowserRouter>
   </React.StrictMode>

--- a/frontend/src/pages/AccessPages.tsx
+++ b/frontend/src/pages/AccessPages.tsx
@@ -1,0 +1,45 @@
+import { Link } from 'react-router-dom';
+import { useAuth } from '../features/auth/AuthContext';
+
+export function AccountPage() {
+  const { user } = useAuth();
+  return (
+    <section className="max-w-2xl rounded-lg border border-slate-800 bg-slate-900 p-6">
+      <p className="text-sm font-medium text-sky-300">Protected route</p>
+      <h1 className="mt-2 text-3xl font-semibold text-white">Account</h1>
+      <p className="mt-4 text-slate-300">
+        Signed in as {user?.displayName ?? 'authenticated user'}.
+      </p>
+    </section>
+  );
+}
+
+export function AdminPage() {
+  return (
+    <section className="max-w-2xl rounded-lg border border-slate-800 bg-slate-900 p-6">
+      <p className="text-sm font-medium text-amber-300">Admin route</p>
+      <h1 className="mt-2 text-3xl font-semibold text-white">Administration</h1>
+      <p className="mt-4 text-slate-300">
+        This client session includes ROLE_ADMIN. Every admin API still enforces authorization on the backend.
+      </p>
+    </section>
+  );
+}
+
+export function ForbiddenPage() {
+  return (
+    <section className="mx-auto max-w-xl rounded-lg border border-amber-700 bg-amber-950/30 p-8 text-center">
+      <p className="text-sm font-medium text-amber-300">403-style access guard</p>
+      <h1 className="mt-2 text-3xl font-semibold text-white">Access forbidden</h1>
+      <p className="mt-4 text-slate-300">
+        This area requires an administrator role.
+      </p>
+      <Link
+        className="mt-6 inline-flex rounded-md bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-white"
+        to="/"
+      >
+        Return home
+      </Link>
+    </section>
+  );
+}


### PR DESCRIPTION
## What changed
- add initialization-aware protected and admin route guards
- preserve the intended path when guests are redirected to sign in
- wire account, admin, and forbidden routes through the centralized router
- expose role-appropriate navigation without treating the frontend as the authorization boundary
- add route, integration, and navigation tests

## Why
Sprint 2 Issue 2.10 requires protected routes to reject unauthenticated users and admin routes to reject users without ROLE_ADMIN while waiting for auth bootstrap before rendering protected content.

## Verification
- npm ci
- npm test -- --run: 9 files, 83 tests passed
- npm run build: passed
- manual Vite smoke: guest /account?tab=security#devices and /admin both redirected to /login
- independent focused review: PASS, 13/13 guard tests
- git diff --check: passed

## Self-review
- [x] Code is buildable and runnable
- [x] Build and IDE artifacts remain excluded
- [x] Commit history is scoped and meaningful
- [x] Diff reviewed for route correctness, role handling, auth initialization, accessibility, and issue scope
- [x] Logout UI is intentionally excluded and will be handled as a separate Sprint 2 completion issue

Closes #26