### PR TITLE
[Feature] Add frontend logout control

### DIFF
--- a/frontend/src/app/AppRoutes.test.tsx
+++ b/frontend/src/app/AppRoutes.test.tsx
@@ -48,6 +48,18 @@ describe('AppRoutes guard wiring', () => {
     expect(await screen.findByRole('heading', { name: 'Administration' })).toBeInTheDocument();
   });
 
+  it('redirects to login after logout from a protected route', async () => {
+    persistUser(regularUser);
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+    renderProductionRoutes('/account');
+
+    expect(await screen.findByRole('heading', { name: 'Account' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Sign out' }));
+
+    await waitFor(() => expect(screen.getByTestId('current-location')).toHaveTextContent('/login'));
+    expect(screen.getByRole('heading', { name: 'Sign in' })).toBeInTheDocument();
+  });
+
   it('preserves the intended route when bootstrap refresh fails before login', async () => {
     persistUser(regularUser, Date.now() + 1_000);
     fetchMock

--- a/frontend/src/components/AppLayout.test.tsx
+++ b/frontend/src/components/AppLayout.test.tsx
@@ -1,8 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { PropsWithChildren } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AuthResponse, UserProfile } from '../lib/api/types';
 import { AuthProvider } from '../features/auth/AuthContext';
 import { createAuthSession, writeAuthSession } from '../features/auth/authStorage';
@@ -16,6 +16,18 @@ const regularUser: UserProfile = {
 };
 
 describe('AppLayout auth navigation', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
   it('shows guest links without protected or admin navigation', async () => {
     renderLayout();
 
@@ -23,6 +35,7 @@ describe('AppLayout auth navigation', () => {
     expect(screen.getByRole('link', { name: 'Register' })).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Account' })).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Admin' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Sign out' })).not.toBeInTheDocument();
   });
 
   it('hides admin navigation from a regular authenticated user', async () => {
@@ -32,6 +45,7 @@ describe('AppLayout auth navigation', () => {
     expect(await screen.findByRole('link', { name: 'Account' })).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Admin' })).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Sign in' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign out' })).toBeEnabled();
   });
 
   it('shows admin navigation only to ROLE_ADMIN', async () => {
@@ -41,6 +55,44 @@ describe('AppLayout auth navigation', () => {
     expect(await screen.findByRole('link', { name: 'Admin' })).toHaveAttribute('href', '/admin');
   });
 
+  it('sends the refresh token once and keeps a stable disabled control while logout is pending', async () => {
+    persistUser(regularUser);
+    let resolveLogout: ((response: Response) => void) | undefined;
+    fetchMock.mockReturnValue(new Promise<Response>((resolve) => {
+      resolveLogout = resolve;
+    }));
+    renderLayout();
+
+    const signOut = await screen.findByRole('button', { name: 'Sign out' });
+    fireEvent.click(signOut);
+    fireEvent.click(signOut);
+
+    const pendingControl = await screen.findByRole('button', { name: 'Signing out…' });
+    expect(pendingControl).toBe(signOut);
+    expect(pendingControl).toBeDisabled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.getItem('vod.auth.session.v1')).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Sign in' })).not.toBeInTheDocument();
+    expectLogoutRequest(fetchMock.mock.calls[0]);
+
+    resolveLogout?.(new Response(null, { status: 204 }));
+    await waitFor(() => expect(screen.getByRole('link', { name: 'Sign in' })).toBeInTheDocument());
+  });
+
+  it('stays signed out and reports an accessible error when revocation fails', async () => {
+    persistUser(regularUser);
+    fetchMock.mockRejectedValue(new TypeError('network unavailable'));
+    renderLayout();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign out' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Signed out locally, but server token revocation could not be confirmed.'
+    );
+    expect(screen.getByRole('link', { name: 'Sign in' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Sign out' })).not.toBeInTheDocument();
+    expect(window.localStorage.getItem('vod.auth.session.v1')).toBeNull();
+  });
 });
 
 function renderLayout() {
@@ -68,4 +120,12 @@ function persistUser(user: UserProfile) {
     expiresInSeconds: 900
   };
   writeAuthSession(createAuthSession(response), window.localStorage);
+}
+
+function expectLogoutRequest(call: [input: RequestInfo | URL, init?: RequestInit]) {
+  const [input, init] = call;
+  expect(input).toBe('/api/v1/auth/logout');
+  expect(init?.method).toBe('POST');
+  expect(new Headers(init?.headers).get('Content-Type')).toBe('application/json');
+  expect(JSON.parse(init?.body?.toString() ?? '{}')).toEqual({ refreshToken: 'refresh-token' });
 }

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1,9 +1,36 @@
+import { useEffect, useRef, useState } from 'react';
 import { Link, NavLink, Outlet } from 'react-router-dom';
 import { useAuth } from '../features/auth/AuthContext';
 
 export function AppLayout() {
-  const { isAuthenticated, isInitializing, user } = useAuth();
+  const { isAuthenticated, isInitializing, logout, user } = useAuth();
   const isAdmin = user?.roles.includes('ROLE_ADMIN') ?? false;
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const [logoutError, setLogoutError] = useState<string | null>(null);
+  const logoutInFlight = useRef(false);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      setLogoutError(null);
+    }
+  }, [isAuthenticated]);
+
+  const signOut = async () => {
+    if (logoutInFlight.current) {
+      return;
+    }
+    logoutInFlight.current = true;
+    setIsLoggingOut(true);
+    setLogoutError(null);
+    try {
+      await logout();
+    } catch {
+      setLogoutError('Signed out locally, but server token revocation could not be confirmed.');
+    } finally {
+      logoutInFlight.current = false;
+      setIsLoggingOut(false);
+    }
+  };
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
@@ -17,13 +44,28 @@ export function AppLayout() {
             aria-label="Primary navigation"
             className="flex min-h-5 items-center gap-4 text-sm"
           >
-            {!isInitializing && isAuthenticated ? (
+            {!isInitializing && (isAuthenticated || isLoggingOut) ? (
               <>
-                <NavLink className={navLinkClass} to="/account">Account</NavLink>
-                {isAdmin ? <NavLink className={navLinkClass} to="/admin">Admin</NavLink> : null}
+                {isAuthenticated ? (
+                  <>
+                    <NavLink className={navLinkClass} to="/account">Account</NavLink>
+                    {isAdmin ? <NavLink className={navLinkClass} to="/admin">Admin</NavLink> : null}
+                  </>
+                ) : null}
+                <button
+                  aria-live="polite"
+                  className={isLoggingOut
+                    ? 'cursor-wait text-slate-500'
+                    : 'text-slate-400 hover:text-slate-200'}
+                  disabled={isLoggingOut}
+                  onClick={() => void signOut()}
+                  type="button"
+                >
+                  {isLoggingOut ? 'Signing out…' : 'Sign out'}
+                </button>
               </>
             ) : null}
-            {!isInitializing && !isAuthenticated ? (
+            {!isInitializing && !isAuthenticated && !isLoggingOut ? (
               <>
                 <NavLink className={navLinkClass} to="/login">Sign in</NavLink>
                 <NavLink className={navLinkClass} to="/register">Register</NavLink>
@@ -32,6 +74,16 @@ export function AppLayout() {
           </nav>
         </div>
       </header>
+      {logoutError ? (
+        <div className="mx-auto mt-4 max-w-6xl px-6">
+          <p
+            className="rounded-md border border-amber-600/60 bg-amber-950/50 p-3 text-sm text-amber-200"
+            role="alert"
+          >
+            {logoutError}
+          </p>
+        </div>
+      ) : null}
       <main className="mx-auto max-w-6xl px-6 py-12">
         <Outlet />
       </main>


### PR DESCRIPTION
## What changed
- add one accessible Sign out control to authenticated global navigation
- keep the same control disabled with live pending feedback while logout is in flight
- preserve immediate local sign-out and show an accessible warning if server revocation fails
- verify logout from a protected route redirects through the existing route guard
- add request, deduplication, failure, navigation, and role-visibility tests

## Why
Sprint 2 Definition of Done requires users to log out through both API and UI. Issue #24 already owns token/session logic and #26 owns route guards, so this completion batch only exposes the existing logout operation in the UI.

## Verification
- targeted UI tests: 2 files, 10/10 passed
- full frontend tests: 9 files, 86/86 passed
- shuffled full frontend tests (seed 39): 9 files, 86/86 passed
- npm run build: passed
- git diff --check: passed
- independent review: PASS, no actionable findings

## Self-review
- [x] Code is buildable and runnable
- [x] Build and IDE artifacts remain excluded
- [x] Commit history is scoped and meaningful
- [x] Shared API client/AuthContext are reused; no raw fetch or token logic was added
- [x] Diff reviewed for async races, double submission, accessibility, route behavior, role visibility, and failure safety
- [x] Only three frontend files differ from the prerequisite branch

Closes #39