### PR TITLE
[Test] Add Sprint 2 auth Postman collection

### DIFF
--- a/docs/testing/postman/README.md
+++ b/docs/testing/postman/README.md
@@ -1,0 +1,69 @@
+# Sprint 2 Auth Postman Collection
+
+This folder contains the executable Sprint 2 authentication subset:
+
+- `vod-platform-sprint-2-auth.postman_collection.json`
+- `vod-platform-local.postman_environment.json`
+
+It verifies registration, login, refresh-token rotation and rejection, authenticated profile access, and logout. It is intentionally not the comprehensive all-MVP collection owned by backlog Issue 10.3.
+
+## Prerequisites
+
+Start the local Compose stack through the Nginx edge by following the repository [local development instructions](../../../README.md#run-the-local-stack). With the default environment, the collection uses:
+
+```text
+http://localhost
+```
+
+If `NGINX_HTTP_PORT` is not `80`, change `baseUrl` in the imported environment, for example to `http://localhost:8088`.
+
+## Run in Postman
+
+1. Import both JSON files.
+2. Select **VoD Platform - Local** as the active environment.
+3. Run the complete **VoD Platform - Sprint 2 Auth** collection in its numbered order.
+4. Confirm that every request and test passes.
+
+The first request generates a unique synthetic `testEmail` for the run. The ordered flow then:
+
+1. registers the user;
+2. proves duplicate registration is rejected;
+3. proves invalid credentials are rejected;
+4. logs in and captures the access and refresh tokens;
+5. rotates the refresh token;
+6. proves the prior refresh token cannot be replayed;
+7. calls the protected current-profile endpoint;
+8. revokes the current refresh token;
+9. proves the logged-out token cannot refresh;
+10. proves repeated logout is idempotent;
+11. proves logout without a submitted token is an idempotent no-op.
+
+Run the whole collection rather than starting in the middle because later requests depend on variables captured by earlier requests.
+
+## Run with Newman
+
+From the repository root:
+
+```bash
+npx --yes newman run docs/testing/postman/vod-platform-sprint-2-auth.postman_collection.json \
+  --environment docs/testing/postman/vod-platform-local.postman_environment.json
+```
+
+Newman exits nonzero when a request, assertion, or script fails. The command does not write runtime tokens back to the committed environment file unless an explicit export option is added.
+
+## Test Data and Secret Safety
+
+- `testPassword` is a synthetic local-only value, not a real credential.
+- The collection generates a new synthetic email on every ordered run.
+- Synthetic users remain in the local PostgreSQL volume after a run.
+- Access and refresh token variables start empty and are marked as secrets.
+- Do not export or commit an environment after it has captured live tokens.
+- Do not point this collection at a shared or production deployment without an explicit test-data and cleanup plan.
+
+## Contract Notes
+
+The frozen OpenAPI contract lists logout as unauthenticated with an optional body and documents both `204` and `401`. Sprint 2 Issue 2.4 and the current implementation are more specific: logout is public and idempotently returns `204` whether the submitted token is active, revoked, unknown, or omitted. This collection verifies the implemented Sprint 2 behavior without changing the frozen architecture documents.
+
+The `ApiError.code` checks are implementation regression evidence. The frozen schema requires a string code but does not define those values as an enum.
+
+No test-only RBAC probe is included. Production admin business endpoints belong to later sprints, and frontend route guards are not a backend authorization boundary.

--- a/docs/testing/postman/vod-platform-local.postman_environment.json
+++ b/docs/testing/postman/vod-platform-local.postman_environment.json
@@ -1,0 +1,57 @@
+{
+  "id": "b1a85955-55d7-4b5f-a076-5be7f129f8c1",
+  "name": "VoD Platform - Local",
+  "values": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "testEmail",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "testPassword",
+      "value": "Sprint2-Postman-Only!42",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "testDisplayName",
+      "value": "Postman Sprint 2 User",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "userId",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "accessToken",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "refreshToken",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "previousRefreshToken",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2026-08-27T00:00:00.000Z",
+  "_postman_exported_using": "Codex"
+}

--- a/docs/testing/postman/vod-platform-sprint-2-auth.postman_collection.json
+++ b/docs/testing/postman/vod-platform-sprint-2-auth.postman_collection.json
@@ -1,0 +1,691 @@
+{
+  "info": {
+    "_postman_id": "42fef3b5-193a-4c60-a39d-d8d5018f4b37",
+    "name": "VoD Platform - Sprint 2 Auth",
+    "description": "Ordered Sprint 2 contract checks for registration, login, refresh rotation, protected profile access, and idempotent logout. This is intentionally narrower than the comprehensive MVP collection reserved for Issue 10.3.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "auth": {
+    "type": "noauth"
+  },
+  "item": [
+    {
+      "name": "01 - Register user",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "const suffix = Date.now() + '-' + pm.variables.replaceIn('{{$randomInt}}');",
+              "pm.environment.set('testEmail', 'postman-auth-' + suffix + '@example.com');",
+              "['userId', 'accessToken', 'refreshToken', 'previousRefreshToken'].forEach((name) => {",
+              "  pm.environment.set(name, '');",
+              "});"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status is 201 Created', () => {",
+              "  pm.response.to.have.status(201);",
+              "});",
+              "",
+              "const body = pm.response.json();",
+              "pm.test('Response matches UserProfile and assigns ROLE_USER', () => {",
+              "  pm.expect(body).to.be.an('object');",
+              "  pm.expect(body.id).to.be.a('string').and.not.empty;",
+              "  pm.expect(body.email).to.equal(pm.environment.get('testEmail'));",
+              "  pm.expect(body.displayName).to.equal(pm.environment.get('testDisplayName'));",
+              "  pm.expect(body.roles).to.be.an('array').that.includes('ROLE_USER');",
+              "});",
+              "pm.test('Registration exposes no password or tokens', () => {",
+              "  ['password', 'passwordHash', 'accessToken', 'refreshToken'].forEach((field) => {",
+              "    pm.expect(body).not.to.have.property(field);",
+              "  });",
+              "});",
+              "",
+              "pm.environment.set('userId', body.id);"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"email\": \"{{testEmail}}\",\n  \"password\": \"{{testPassword}}\",\n  \"displayName\": \"{{testDisplayName}}\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/auth/register",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "auth",
+            "register"
+          ]
+        },
+        "description": "Creates one synthetic ACTIVE user with ROLE_USER. The pre-request script generates a unique email for each ordered run."
+      },
+      "response": []
+    },
+    {
+      "name": "02 - Reject duplicate registration",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status is 409 Conflict', () => {",
+              "  pm.response.to.have.status(409);",
+              "});",
+              "",
+              "const error = pm.response.json();",
+              "pm.test('Response matches ApiError', () => {",
+              "  pm.expect(error).to.include.keys('timestamp', 'status', 'code', 'message');",
+              "  pm.expect(error.status).to.equal(409);",
+              "  pm.expect(error.timestamp).to.be.a('string').and.not.empty;",
+              "  pm.expect(error.message).to.be.a('string').and.not.empty;",
+              "});",
+              "pm.test('Implementation regression code is EMAIL_ALREADY_EXISTS', () => {",
+              "  pm.expect(error.code).to.equal('EMAIL_ALREADY_EXISTS');",
+              "});"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"email\": \"{{testEmail}}\",\n  \"password\": \"{{testPassword}}\",\n  \"displayName\": \"{{testDisplayName}}\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/auth/register",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "auth",
+            "register"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "03 - Reject invalid login",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status is 401 Unauthorized', () => {",
+              "  pm.response.to.have.status(401);",
+              "});",
+              "",
+              "const error = pm.response.json();",
+              "pm.test('Response matches generic authentication ApiError', () => {",
+              "  pm.expect(error).to.include.keys('timestamp', 'status', 'code', 'message');",
+              "  pm.expect(error.status).to.equal(401);",
+              "  pm.expect(error.message).to.be.a('string').and.not.empty;",
+              "});",
+              "pm.test('Implementation regression code is INVALID_CREDENTIALS', () => {",
+              "  pm.expect(error.code).to.equal('INVALID_CREDENTIALS');",
+              "});"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"email\": \"{{testEmail}}\",\n  \"password\": \"{{testPassword}}-wrong\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/auth/login",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "auth",
+            "login"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "04 - Login and capture tokens",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status is 200 OK', () => {",
+              "  pm.response.to.have.status(200);",
+              "});",
+              "",
+              "const body = pm.response.json();",
+              "pm.test('Response matches AuthResponse', () => {",
+              "  pm.expect(body.user).to.be.an('object');",
+              "  pm.expect(body.user.id).to.equal(pm.environment.get('userId'));",
+              "  pm.expect(body.user.email).to.equal(pm.environment.get('testEmail'));",
+              "  pm.expect(body.user.displayName).to.equal(pm.environment.get('testDisplayName'));",
+              "  pm.expect(body.user.roles).to.include('ROLE_USER');",
+              "  pm.expect(body.accessToken).to.be.a('string').and.not.empty;",
+              "  pm.expect(body.refreshToken).to.be.a('string').and.not.empty;",
+              "  pm.expect(body.expiresInSeconds).to.be.a('number').and.above(0);",
+              "  pm.expect(Number.isInteger(body.expiresInSeconds)).to.equal(true);",
+              "  ['password', 'passwordHash'].forEach((field) => {",
+              "    pm.expect(body.user).not.to.have.property(field);",
+              "  });",
+              "});",
+              "",
+              "pm.environment.set('accessToken', body.accessToken);",
+              "pm.environment.set('refreshToken', body.refreshToken);"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"email\": \"{{testEmail}}\",\n  \"password\": \"{{testPassword}}\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/auth/login",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "auth",
+            "login"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "05 - Refresh and rotate tokens",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.environment.set('previousRefreshToken', pm.environment.get('refreshToken'));"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status is 200 OK', () => {",
+              "  pm.response.to.have.status(200);",
+              "});",
+              "",
+              "const body = pm.response.json();",
+              "const previousRefreshToken = pm.environment.get('previousRefreshToken');",
+              "pm.test('Refresh returns a rotated AuthResponse for the same user', () => {",
+              "  pm.expect(body.user.id).to.equal(pm.environment.get('userId'));",
+              "  pm.expect(body.user.email).to.equal(pm.environment.get('testEmail'));",
+              "  pm.expect(body.user.displayName).to.equal(pm.environment.get('testDisplayName'));",
+              "  pm.expect(body.user.roles).to.include('ROLE_USER');",
+              "  pm.expect(body.accessToken).to.be.a('string').and.not.empty;",
+              "  pm.expect(body.refreshToken).to.be.a('string').and.not.empty;",
+              "  pm.expect(body.refreshToken).not.to.equal(previousRefreshToken);",
+              "  pm.expect(body.expiresInSeconds).to.be.a('number').and.above(0);",
+              "  pm.expect(Number.isInteger(body.expiresInSeconds)).to.equal(true);",
+              "  ['password', 'passwordHash'].forEach((field) => {",
+              "    pm.expect(body.user).not.to.have.property(field);",
+              "  });",
+              "});",
+              "",
+              "pm.environment.set('accessToken', body.accessToken);",
+              "pm.environment.set('refreshToken', body.refreshToken);"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"refreshToken\": \"{{refreshToken}}\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/auth/refresh",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "auth",
+            "refresh"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "06 - Reject replayed refresh token",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status is 401 Unauthorized', () => {",
+              "  pm.response.to.have.status(401);",
+              "});",
+              "",
+              "const error = pm.response.json();",
+              "pm.test('Response matches ApiError', () => {",
+              "  pm.expect(error).to.include.keys('timestamp', 'status', 'code', 'message');",
+              "  pm.expect(error.status).to.equal(401);",
+              "});",
+              "pm.test('Implementation regression code is INVALID_REFRESH_TOKEN', () => {",
+              "  pm.expect(error.code).to.equal('INVALID_REFRESH_TOKEN');",
+              "});"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"refreshToken\": \"{{previousRefreshToken}}\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/auth/refresh",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "auth",
+            "refresh"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "07 - Get authenticated user profile",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status is 200 OK', () => {",
+              "  pm.response.to.have.status(200);",
+              "});",
+              "",
+              "const body = pm.response.json();",
+              "pm.test('Response matches the authenticated UserProfile', () => {",
+              "  pm.expect(body.id).to.equal(pm.environment.get('userId'));",
+              "  pm.expect(body.email).to.equal(pm.environment.get('testEmail'));",
+              "  pm.expect(body.displayName).to.equal(pm.environment.get('testDisplayName'));",
+              "  pm.expect(body.roles).to.include('ROLE_USER');",
+              "});",
+              "pm.test('Profile exposes no password data', () => {",
+              "  ['password', 'passwordHash'].forEach((field) => {",
+              "    pm.expect(body).not.to.have.property(field);",
+              "  });",
+              "});"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{accessToken}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/users/me",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "users",
+            "me"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "08 - Logout current refresh token",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status is 204 No Content', () => {",
+              "  pm.response.to.have.status(204);",
+              "});",
+              "pm.test('Response body is empty', () => {",
+              "  pm.expect(pm.response.text()).to.equal('');",
+              "});"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"refreshToken\": \"{{refreshToken}}\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/auth/logout",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "auth",
+            "logout"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "09 - Reject refresh after logout",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status is 401 Unauthorized', () => {",
+              "  pm.response.to.have.status(401);",
+              "});",
+              "",
+              "const error = pm.response.json();",
+              "pm.test('Response matches ApiError', () => {",
+              "  pm.expect(error).to.include.keys('timestamp', 'status', 'code', 'message');",
+              "  pm.expect(error.status).to.equal(401);",
+              "});",
+              "pm.test('Implementation regression code is INVALID_REFRESH_TOKEN', () => {",
+              "  pm.expect(error.code).to.equal('INVALID_REFRESH_TOKEN');",
+              "});"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"refreshToken\": \"{{refreshToken}}\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/auth/refresh",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "auth",
+            "refresh"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "10 - Repeat logout idempotently",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status remains 204 No Content', () => {",
+              "  pm.response.to.have.status(204);",
+              "});",
+              "pm.test('Response body remains empty', () => {",
+              "  pm.expect(pm.response.text()).to.equal('');",
+              "});"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"refreshToken\": \"{{refreshToken}}\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/auth/logout",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "auth",
+            "logout"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "11 - Logout without a token idempotently",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status is 204 No Content', () => {",
+              "  pm.response.to.have.status(204);",
+              "});",
+              "pm.test('Response body is empty', () => {",
+              "  pm.expect(pm.response.text()).to.equal('');",
+              "});"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/api/v1/auth/logout",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "auth",
+            "logout"
+          ]
+        },
+        "description": "The Sprint 2 implementation deliberately treats an omitted refresh token as an idempotent no-op."
+      },
+      "response": []
+    }
+  ]
+}


### PR DESCRIPTION
## What changed
- add a Postman Collection v2.1 for the ordered Sprint 2 auth flow
- add a local Postman environment with blank secret token variables and synthetic test credentials
- add usage, Newman, persistence, security, and scope notes under `docs/testing/postman/`

## Why
This completes the Sprint 2 authentication collection gap without expanding into the comprehensive MVP collection reserved for Issue 10.3.

Closes #41

## Verification
- both JSON artifacts parse successfully; all 13 Postman scripts parse
- Newman 6.2.2 against the actual local Compose stack: 11/11 requests, 28/28 assertions, 0 failures
- backend `mvn -B verify`: 12/12 modules, 72/72 tests
- worker `mvn -B verify`: 7/7 modules, 1/1 test
- frontend `npm test`: 9/9 files, 86/86 tests
- frontend `npm run build`: success
- `git diff --check`: clean

## Self-review
- [x] Is the code buildable and runnable?
- [x] Are build/IDE files such as `target/`, `.idea/`, and `*.iml` excluded?
- [x] Is the commit history clean and meaningful?
- [x] Exact frozen API paths and JSON field names were checked against `docs/architecture/API-CONTRACT.yaml`.
- [x] Access and refresh token defaults are blank and marked secret; no real credentials or tokens are committed.
- [x] The incremental three-dot diff contains only Issue #41 files.

This self-review supports independent review and is not a substitute for it.