### PR TITLE
[Fix] Support SPA deep links through Nginx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Build frontend image
         run: docker build -t vod-frontend-skeleton ./frontend
 
+      - name: Verify Nginx SPA and reserved route boundaries
+        run: sh deploy/tests/nginx-routing-smoke.sh vod-frontend-skeleton
+
       - name: Build compose application images
         run: docker compose -f deploy/docker-compose.yml build backend worker frontend
 

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -26,6 +26,10 @@ http {
         add_header X-Frame-Options "DENY" always;
         add_header Referrer-Policy "no-referrer" always;
 
+        location = /api/v1 {
+            return 404;
+        }
+
         location /api/v1/ {
             proxy_pass http://backend_upstream/api/v1/;
             proxy_http_version 1.1;
@@ -35,6 +39,10 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Request-ID $request_id;
             proxy_set_header Authorization $http_authorization;
+        }
+
+        location = /hls {
+            return 404;
         }
 
         location /hls/ {

--- a/deploy/tests/nginx-routing-smoke.sh
+++ b/deploy/tests/nginx-routing-smoke.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env sh
+
+set -eu
+
+frontend_image="${1:-vod-frontend-routing-test}"
+test_id="$$"
+network_name="vod-nginx-routing-test-${test_id}"
+frontend_container="vod-frontend-routing-test-${test_id}"
+backend_container="vod-backend-routing-stub-${test_id}"
+edge_container="vod-edge-routing-test-${test_id}"
+script_directory="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+repository_root="$(CDPATH= cd -- "${script_directory}/../.." && pwd)"
+
+cleanup() {
+    docker rm -f \
+        "${edge_container}" \
+        "${backend_container}" \
+        "${frontend_container}" >/dev/null 2>&1 || true
+    docker network rm "${network_name}" >/dev/null 2>&1 || true
+}
+
+fail() {
+    printf '%s\n' "$1" >&2
+    exit 1
+}
+
+assert_spa_route() {
+    route="$1"
+    body="$(curl --fail --silent --show-error "${edge_url}${route}")"
+    printf '%s' "${body}" | grep --fixed-strings --quiet '<div id="root"></div>' \
+        || fail "Expected React application shell for ${route}"
+}
+
+assert_reserved_route() {
+    route="$1"
+    body="$(curl --silent --show-error "${edge_url}${route}")"
+    if printf '%s' "${body}" | grep --fixed-strings --quiet '<div id="root"></div>'; then
+        fail "Reserved route ${route} unexpectedly returned the React application shell"
+    fi
+}
+
+trap cleanup EXIT INT TERM
+
+docker network create "${network_name}" >/dev/null
+docker run --detach --name "${frontend_container}" \
+    --network "${network_name}" --network-alias frontend \
+    "${frontend_image}" >/dev/null
+docker run --detach --name "${backend_container}" \
+    --network "${network_name}" --network-alias backend \
+    nginx:1.27-alpine >/dev/null
+docker run --detach --name "${edge_container}" \
+    --network "${network_name}" \
+    --publish 127.0.0.1::80 \
+    --volume "${repository_root}/deploy/nginx/nginx.conf:/etc/nginx/nginx.conf:ro" \
+    nginx:1.27-alpine >/dev/null
+
+published_address="$(docker port "${edge_container}" 80/tcp)"
+edge_port="${published_address##*:}"
+edge_url="http://127.0.0.1:${edge_port}"
+
+attempt=0
+until curl --fail --silent --show-error --output /dev/null "${edge_url}/"; do
+    attempt=$((attempt + 1))
+    if [ "${attempt}" -ge 30 ]; then
+        docker logs "${edge_container}" >&2 || true
+        fail 'Nginx routing smoke stack did not become ready'
+    fi
+    sleep 1
+done
+
+for route in / /login /register /account /admin; do
+    assert_spa_route "${route}"
+done
+
+for route in \
+    /api/v1 \
+    /api/v1/health \
+    /api/v1/__spa_probe__ \
+    /hls \
+    /hls/__spa_probe__.m3u8 \
+    /actuator/health; do
+    assert_reserved_route "${route}"
+done
+
+printf '%s\n' 'Nginx SPA and reserved-route smoke checks passed.'

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,6 +10,7 @@ RUN npm run build
 
 FROM nginx:1.27-alpine
 
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /workspace/dist /usr/share/nginx/html
 
 EXPOSE 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## What changed

- added a frontend-container Nginx configuration with SPA history fallback for React Router paths
- added exact edge guards for `/api/v1` and `/hls` so namespace roots cannot fall into the SPA fallback
- preserved the existing backend-only `/api/v1/*`, backend HLS `/hls/*`, and health routing
- added a reusable real-container smoke test and wired it into the Skeleton build checks

## Why

The public edge correctly forwarded frontend paths to the frontend service, but that service used stock Nginx file lookup. Direct navigation or reload of `/login`, `/register`, `/account`, and `/admin` therefore returned 404 before React Router could run. The inner frontend Nginx owns static-file resolution, while the public edge continues to own reserved namespace isolation.

Implements #43. This Draft PR is stacked on Draft PR #42 and must be reviewed and merged after its prerequisite stack.

## Verification

- frontend Vitest: 9 files, 86 tests passed
- frontend production build passed
- full backend Maven reactor: 12 modules passed; 72 tests passed
- full worker Maven reactor: 7 modules passed; 1 test passed
- local + production Compose config validation passed
- built-image Nginx smoke passed for `/`, `/login`, `/register`, `/account`, `/admin`, API, HLS, and health namespaces
- actual Compose runtime reached 8 healthy services plus 2 successful init jobs
- public-edge probes confirmed SPA routes return React while API/HLS probes never do
- headless Chrome confirmed public route reloads, guest redirects, authenticated `/account` reload, regular-user `/admin` blocking, registration/login, and logout
- Newman auth flow: 11 requests and 28 assertions passed

## Self-review

- [x] Is the code buildable and runnable?
- [x] Are build/IDE files (like target/, .idea/, *.iml) excluded?
- [x] Is the commit history clean and meaningful?
- [x] Verified the incremental three-dot diff contains only Issue #43 files.
- [x] Verified no frozen API, security, or architecture document changed.
- [x] Reviewed routing for SPA fallback leakage, API/HLS isolation, health behavior, cleanup safety, and scope.
- [x] This self-review is not a substitute for independent review.