### PR TITLE
[Fix] Fail closed on production credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+# Local development template only. Production rejects the published credential placeholders below.
+
 # App
 APP_ENV=local
 APP_BASE_URL=http://localhost

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+deploy/tests/*.sh text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate compose config
-        run: docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.prod.yml config
+      - name: Verify production configuration fails closed
+        run: sh deploy/tests/production-config-smoke.sh
 
       - name: Build backend image
         run: docker build -t vod-backend-skeleton ./backend

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,5 +1,32 @@
 services:
+  production-config-check:
+    image: postgres:16-alpine
+    entrypoint: ["/bin/sh", "/checks/production-config-check.sh"]
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:?Set a non-default production PostgreSQL username}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set a non-default production PostgreSQL password}
+      RABBITMQ_USERNAME: ${RABBITMQ_USERNAME:?Set a non-default production RabbitMQ username}
+      RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD:?Set a non-default production RabbitMQ password}
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:?Set a non-default production MinIO access key}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:?Set a non-default production MinIO secret key}
+      JWT_SECRET: ${JWT_SECRET:?Set a non-default production JWT signing secret}
+    volumes:
+      - ./tests/production-config-check.sh:/checks/production-config-check.sh:ro
+    network_mode: none
+    restart: "no"
+    deploy:
+      resources:
+        limits:
+          cpus: "0.10"
+          memory: 32M
+
   postgres:
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:?Set a non-default production PostgreSQL username}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set a non-default production PostgreSQL password}
+    depends_on:
+      production-config-check:
+        condition: service_completed_successfully
     restart: unless-stopped
     deploy:
       resources:
@@ -18,6 +45,12 @@ services:
           memory: 256M
 
   rabbitmq:
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USERNAME:?Set a non-default production RabbitMQ username}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD:?Set a non-default production RabbitMQ password}
+    depends_on:
+      production-config-check:
+        condition: service_completed_successfully
     restart: unless-stopped
     deploy:
       resources:
@@ -26,6 +59,12 @@ services:
           memory: 512M
 
   minio:
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ACCESS_KEY:?Set a non-default production MinIO access key}
+      MINIO_ROOT_PASSWORD: ${MINIO_SECRET_KEY:?Set a non-default production MinIO secret key}
+    depends_on:
+      production-config-check:
+        condition: service_completed_successfully
     restart: unless-stopped
     deploy:
       resources:
@@ -34,6 +73,14 @@ services:
           memory: 512M
 
   backend:
+    environment:
+      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER:?Set a non-default production PostgreSQL username}
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:?Set a non-default production PostgreSQL password}
+      JWT_SECRET: ${JWT_SECRET:?Set a non-default production JWT signing secret}
+      RABBITMQ_USERNAME: ${RABBITMQ_USERNAME:?Set a non-default production RabbitMQ username}
+      RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD:?Set a non-default production RabbitMQ password}
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:?Set a non-default production MinIO access key}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:?Set a non-default production MinIO secret key}
     restart: unless-stopped
     deploy:
       resources:
@@ -42,6 +89,13 @@ services:
           memory: 768M
 
   worker:
+    environment:
+      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER:?Set a non-default production PostgreSQL username}
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:?Set a non-default production PostgreSQL password}
+      RABBITMQ_USERNAME: ${RABBITMQ_USERNAME:?Set a non-default production RabbitMQ username}
+      RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD:?Set a non-default production RabbitMQ password}
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:?Set a non-default production MinIO access key}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:?Set a non-default production MinIO secret key}
     restart: unless-stopped
     deploy:
       resources:
@@ -58,6 +112,12 @@ services:
           memory: 128M
 
   flyway:
+    environment:
+      FLYWAY_USER: ${POSTGRES_USER:?Set a non-default production PostgreSQL username}
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:?Set a non-default production PostgreSQL password}
+    depends_on:
+      production-config-check:
+        condition: service_completed_successfully
     deploy:
       resources:
         limits:
@@ -65,6 +125,12 @@ services:
           memory: 256M
 
   minio-init:
+    environment:
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:?Set a non-default production MinIO access key}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:?Set a non-default production MinIO secret key}
+    depends_on:
+      production-config-check:
+        condition: service_completed_successfully
     deploy:
       resources:
         limits:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-vod_app} -d ${POSTGRES_DB:-vod_platform}"]
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -65,12 +65,13 @@ services:
 
   flyway:
     image: flyway/flyway:12.10.0
+    environment:
+      FLYWAY_URL: jdbc:postgresql://${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-vod_platform}
+      FLYWAY_USER: ${POSTGRES_USER:-vod_app}
+      FLYWAY_PASSWORD: ${POSTGRES_PASSWORD:-change-me}
+      FLYWAY_CONNECT_RETRIES: "60"
+      FLYWAY_LOCATIONS: filesystem:/flyway/sql
     command:
-      - -url=jdbc:postgresql://${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-vod_platform}
-      - -user=${POSTGRES_USER:-vod_app}
-      - -password=${POSTGRES_PASSWORD:-change-me}
-      - -connectRetries=60
-      - -locations=filesystem:/flyway/sql
       - migrate
     volumes:
       - ../backend/common/src/main/resources/db/migration:/flyway/sql:ro
@@ -82,19 +83,26 @@ services:
 
   minio-init:
     image: minio/mc:latest
+    environment:
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-vod_minio}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-change-me}
+      MINIO_BUCKET_RAW: ${MINIO_BUCKET_RAW:-vod-raw}
+      MINIO_BUCKET_HLS: ${MINIO_BUCKET_HLS:-vod-hls}
+      MINIO_BUCKET_THUMBNAILS: ${MINIO_BUCKET_THUMBNAILS:-vod-thumbnails}
     depends_on:
       minio:
         condition: service_healthy
-    entrypoint: >
-      /bin/sh -c "
-      until mc alias set local http://minio:9000 ${MINIO_ACCESS_KEY:-vod_minio} ${MINIO_SECRET_KEY:-change-me}; do sleep 2; done;
-      mc mb --ignore-existing local/${MINIO_BUCKET_RAW:-vod-raw};
-      mc mb --ignore-existing local/${MINIO_BUCKET_HLS:-vod-hls};
-      mc mb --ignore-existing local/${MINIO_BUCKET_THUMBNAILS:-vod-thumbnails};
-      mc anonymous set none local/${MINIO_BUCKET_RAW:-vod-raw};
-      mc anonymous set none local/${MINIO_BUCKET_HLS:-vod-hls};
-      mc anonymous set none local/${MINIO_BUCKET_THUMBNAILS:-vod-thumbnails};
-      "
+    entrypoint:
+      - /bin/sh
+      - -ec
+      - |
+        until mc alias set local http://minio:9000 "$${MINIO_ACCESS_KEY}" "$${MINIO_SECRET_KEY}"; do sleep 2; done
+        mc mb --ignore-existing "local/$${MINIO_BUCKET_RAW}"
+        mc mb --ignore-existing "local/$${MINIO_BUCKET_HLS}"
+        mc mb --ignore-existing "local/$${MINIO_BUCKET_THUMBNAILS}"
+        mc anonymous set none "local/$${MINIO_BUCKET_RAW}"
+        mc anonymous set none "local/$${MINIO_BUCKET_HLS}"
+        mc anonymous set none "local/$${MINIO_BUCKET_THUMBNAILS}"
     networks:
       - vod_internal
 

--- a/deploy/tests/production-config-check.sh
+++ b/deploy/tests/production-config-check.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+set -eu
+
+fail() {
+  printf '%s\n' "Production configuration rejected: $1" >&2
+  exit 1
+}
+
+reject_published_default() {
+  variable_name="$1"
+  value="$2"
+  published_default="$3"
+
+  case "$value" in
+    *[![:space:]]*) ;;
+    *) fail "$variable_name must not be blank" ;;
+  esac
+  [ "$value" != "$published_default" ] \
+    || fail "$variable_name uses a published development default"
+}
+
+reject_published_default "POSTGRES_USER" "${POSTGRES_USER:-}" "vod_app"
+reject_published_default "POSTGRES_PASSWORD" "${POSTGRES_PASSWORD:-}" "change-me"
+reject_published_default "RABBITMQ_USERNAME" "${RABBITMQ_USERNAME:-}" "vod_app"
+reject_published_default "RABBITMQ_PASSWORD" "${RABBITMQ_PASSWORD:-}" "change-me"
+reject_published_default "MINIO_ACCESS_KEY" "${MINIO_ACCESS_KEY:-}" "vod_minio"
+reject_published_default "MINIO_SECRET_KEY" "${MINIO_SECRET_KEY:-}" "change-me"
+reject_published_default \
+  "JWT_SECRET" \
+  "${JWT_SECRET:-}" \
+  "change-me-use-a-long-random-secret"
+
+printf '%s\n' "Production credential preflight passed"

--- a/deploy/tests/production-config-smoke.sh
+++ b/deploy/tests/production-config-smoke.sh
@@ -1,0 +1,293 @@
+#!/bin/sh
+
+set -eu
+
+repository_root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+check_script="$repository_root/deploy/tests/production-config-check.sh"
+temp_directory=$(mktemp -d)
+log_file="$temp_directory/output.log"
+env_file="$temp_directory/production.env"
+config_json="$temp_directory/compose.json"
+compose_project="vod-production-config-test-$$"
+
+set_synthetic_values() {
+  postgres_user_value="ci_postgres_user"
+  postgres_password_value="ci-postgres-password-46"
+  rabbitmq_username_value="ci_rabbitmq_user"
+  rabbitmq_password_value="ci-rabbitmq-password-46"
+  minio_access_key_value="ci_minio_access_key"
+  minio_secret_key_value="ci-minio-secret-key-46"
+  jwt_secret_value="ci-jwt-signing-secret-with-at-least-thirty-two-bytes"
+}
+
+set_published_defaults() {
+  postgres_user_value="vod_app"
+  postgres_password_value="change-me"
+  rabbitmq_username_value="vod_app"
+  rabbitmq_password_value="change-me"
+  minio_access_key_value="vod_minio"
+  minio_secret_key_value="change-me"
+  jwt_secret_value="change-me-use-a-long-random-secret"
+}
+
+value_for() {
+  case "$1" in
+    POSTGRES_USER) printf '%s' "$postgres_user_value" ;;
+    POSTGRES_PASSWORD) printf '%s' "$postgres_password_value" ;;
+    RABBITMQ_USERNAME) printf '%s' "$rabbitmq_username_value" ;;
+    RABBITMQ_PASSWORD) printf '%s' "$rabbitmq_password_value" ;;
+    MINIO_ACCESS_KEY) printf '%s' "$minio_access_key_value" ;;
+    MINIO_SECRET_KEY) printf '%s' "$minio_secret_key_value" ;;
+    JWT_SECRET) printf '%s' "$jwt_secret_value" ;;
+    *) printf '%s\n' "Unknown test variable: $1" >&2; exit 1 ;;
+  esac
+}
+
+write_env_file() {
+  omitted_variable="${1:-}"
+  empty_variable="${2:-}"
+  : > "$env_file"
+
+  for credential_name in \
+    POSTGRES_USER \
+    POSTGRES_PASSWORD \
+    RABBITMQ_USERNAME \
+    RABBITMQ_PASSWORD \
+    MINIO_ACCESS_KEY \
+    MINIO_SECRET_KEY \
+    JWT_SECRET
+  do
+    [ "$credential_name" = "$omitted_variable" ] && continue
+    if [ "$credential_name" = "$empty_variable" ]; then
+      printf '%s=\n' "$credential_name" >> "$env_file"
+    else
+      printf '%s=%s\n' "$credential_name" "$(value_for "$credential_name")" >> "$env_file"
+    fi
+  done
+}
+
+run_check() {
+  POSTGRES_USER="$postgres_user_value" \
+  POSTGRES_PASSWORD="$postgres_password_value" \
+  RABBITMQ_USERNAME="$rabbitmq_username_value" \
+  RABBITMQ_PASSWORD="$rabbitmq_password_value" \
+  MINIO_ACCESS_KEY="$minio_access_key_value" \
+  MINIO_SECRET_KEY="$minio_secret_key_value" \
+  JWT_SECRET="$jwt_secret_value" \
+    sh "$check_script"
+}
+
+run_production_compose() {
+  POSTGRES_USER="$postgres_user_value" \
+  POSTGRES_PASSWORD="$postgres_password_value" \
+  RABBITMQ_USERNAME="$rabbitmq_username_value" \
+  RABBITMQ_PASSWORD="$rabbitmq_password_value" \
+  MINIO_ACCESS_KEY="$minio_access_key_value" \
+  MINIO_SECRET_KEY="$minio_secret_key_value" \
+  JWT_SECRET="$jwt_secret_value" \
+    docker compose \
+      -p "$compose_project" \
+      -f deploy/docker-compose.yml \
+      -f deploy/docker-compose.prod.yml \
+      "$@"
+}
+
+run_production_compose_from_file() {
+  env \
+    -u POSTGRES_USER \
+    -u POSTGRES_PASSWORD \
+    -u RABBITMQ_USERNAME \
+    -u RABBITMQ_PASSWORD \
+    -u MINIO_ACCESS_KEY \
+    -u MINIO_SECRET_KEY \
+    -u JWT_SECRET \
+    docker compose \
+      --env-file "$env_file" \
+      -p "$compose_project" \
+      -f deploy/docker-compose.yml \
+      -f deploy/docker-compose.prod.yml \
+      "$@"
+}
+
+cleanup() {
+  set_synthetic_values
+  run_production_compose down --volumes --remove-orphans >/dev/null 2>&1 || true
+  if [ -n "$temp_directory" ] && [ -d "$temp_directory" ]; then
+    rm -rf -- "$temp_directory"
+  fi
+}
+
+assert_log_contains() {
+  expected_text="$1"
+  if ! grep -Fq "$expected_text" "$log_file"; then
+    printf '%s: %s\n' \
+      "Expected production preflight failure was not observed" \
+      "$expected_text" >&2
+    exit 1
+  fi
+}
+
+expect_default_rejection() {
+  variable_name="$1"
+  published_default="$2"
+
+  set_synthetic_values
+  case "$variable_name" in
+    POSTGRES_USER) postgres_user_value="$published_default" ;;
+    POSTGRES_PASSWORD) postgres_password_value="$published_default" ;;
+    RABBITMQ_USERNAME) rabbitmq_username_value="$published_default" ;;
+    RABBITMQ_PASSWORD) rabbitmq_password_value="$published_default" ;;
+    MINIO_ACCESS_KEY) minio_access_key_value="$published_default" ;;
+    MINIO_SECRET_KEY) minio_secret_key_value="$published_default" ;;
+    JWT_SECRET) jwt_secret_value="$published_default" ;;
+  esac
+
+  : > "$log_file"
+  if run_check > "$log_file" 2>&1; then
+    printf '%s\n' "$variable_name published default was accepted" >&2
+    exit 1
+  fi
+
+  assert_log_contains \
+    "Production configuration rejected: $variable_name uses a published development default"
+  if grep -Fq "$published_default" "$log_file"; then
+    printf '%s\n' "$variable_name value leaked into preflight output" >&2
+    exit 1
+  fi
+}
+
+trap cleanup EXIT
+
+cd "$repository_root"
+
+docker compose \
+  --env-file .env.example \
+  -f deploy/docker-compose.yml \
+  config --quiet
+printf '%s\n' "Local Compose configuration passed"
+
+set_synthetic_values
+run_check >/dev/null
+
+expect_default_rejection "POSTGRES_USER" "vod_app"
+expect_default_rejection "POSTGRES_PASSWORD" "change-me"
+expect_default_rejection "RABBITMQ_USERNAME" "vod_app"
+expect_default_rejection "RABBITMQ_PASSWORD" "change-me"
+expect_default_rejection "MINIO_ACCESS_KEY" "vod_minio"
+expect_default_rejection "MINIO_SECRET_KEY" "change-me"
+expect_default_rejection "JWT_SECRET" "change-me-use-a-long-random-secret"
+printf '%s\n' "Published-default rejection checks passed"
+
+for variable_name in \
+  POSTGRES_USER \
+  POSTGRES_PASSWORD \
+  RABBITMQ_USERNAME \
+  RABBITMQ_PASSWORD \
+  MINIO_ACCESS_KEY \
+  MINIO_SECRET_KEY \
+  JWT_SECRET
+do
+  set_synthetic_values
+  write_env_file "$variable_name" ""
+  : > "$log_file"
+  if run_production_compose_from_file config --quiet > "$log_file" 2>&1; then
+    printf '%s\n' "Production Compose accepted missing $variable_name" >&2
+    exit 1
+  fi
+  assert_log_contains "$variable_name"
+
+  write_env_file "" "$variable_name"
+  : > "$log_file"
+  if run_production_compose_from_file config --quiet > "$log_file" 2>&1; then
+    printf '%s\n' "Production Compose accepted empty $variable_name" >&2
+    exit 1
+  fi
+  assert_log_contains "$variable_name"
+done
+printf '%s\n' "Missing and empty production-variable checks passed"
+
+set_published_defaults
+: > "$log_file"
+if run_production_compose run --rm --no-deps production-config-check \
+  > "$log_file" 2>&1
+then
+  printf '%s\n' "Production preflight accepted published defaults" >&2
+  exit 1
+fi
+assert_log_contains \
+  "Production configuration rejected: POSTGRES_USER uses a published development default"
+
+: > "$log_file"
+if run_production_compose up --no-build --wait --wait-timeout 30 \
+  postgres rabbitmq minio > "$log_file" 2>&1
+then
+  printf '%s\n' "Infrastructure started after a failed production preflight" >&2
+  exit 1
+fi
+
+for service_name in postgres rabbitmq minio
+do
+  if [ -n "$(run_production_compose ps --status running -q "$service_name")" ]; then
+    printf '%s\n' "$service_name started before the production preflight passed" >&2
+    exit 1
+  fi
+done
+printf '%s\n' "Production dependency gate check passed"
+
+set_synthetic_values
+run_production_compose config --format json > "$config_json"
+python3 - "$config_json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as config_file:
+    services = json.load(config_file)["services"]
+
+expected = {
+    "production-config-check": {
+        "POSTGRES_USER": "ci_postgres_user",
+        "POSTGRES_PASSWORD": "ci-postgres-password-46",
+        "RABBITMQ_USERNAME": "ci_rabbitmq_user",
+        "RABBITMQ_PASSWORD": "ci-rabbitmq-password-46",
+        "MINIO_ACCESS_KEY": "ci_minio_access_key",
+        "MINIO_SECRET_KEY": "ci-minio-secret-key-46",
+        "JWT_SECRET": "ci-jwt-signing-secret-with-at-least-thirty-two-bytes",
+    },
+    "postgres": {"POSTGRES_USER": "ci_postgres_user", "POSTGRES_PASSWORD": "ci-postgres-password-46"},
+    "rabbitmq": {"RABBITMQ_DEFAULT_USER": "ci_rabbitmq_user", "RABBITMQ_DEFAULT_PASS": "ci-rabbitmq-password-46"},
+    "minio": {"MINIO_ROOT_USER": "ci_minio_access_key", "MINIO_ROOT_PASSWORD": "ci-minio-secret-key-46"},
+    "flyway": {"FLYWAY_USER": "ci_postgres_user", "FLYWAY_PASSWORD": "ci-postgres-password-46"},
+    "minio-init": {"MINIO_ACCESS_KEY": "ci_minio_access_key", "MINIO_SECRET_KEY": "ci-minio-secret-key-46"},
+    "backend": {
+        "SPRING_DATASOURCE_USERNAME": "ci_postgres_user",
+        "SPRING_DATASOURCE_PASSWORD": "ci-postgres-password-46",
+        "JWT_SECRET": "ci-jwt-signing-secret-with-at-least-thirty-two-bytes",
+        "RABBITMQ_USERNAME": "ci_rabbitmq_user",
+        "RABBITMQ_PASSWORD": "ci-rabbitmq-password-46",
+        "MINIO_ACCESS_KEY": "ci_minio_access_key",
+        "MINIO_SECRET_KEY": "ci-minio-secret-key-46",
+    },
+    "worker": {
+        "SPRING_DATASOURCE_USERNAME": "ci_postgres_user",
+        "SPRING_DATASOURCE_PASSWORD": "ci-postgres-password-46",
+        "RABBITMQ_USERNAME": "ci_rabbitmq_user",
+        "RABBITMQ_PASSWORD": "ci-rabbitmq-password-46",
+        "MINIO_ACCESS_KEY": "ci_minio_access_key",
+        "MINIO_SECRET_KEY": "ci-minio-secret-key-46",
+    },
+}
+
+for service_name, environment in expected.items():
+    actual_environment = services[service_name]["environment"]
+    for variable_name, expected_value in environment.items():
+        assert actual_environment[variable_name] == expected_value, (service_name, variable_name)
+
+for service_name in ("postgres", "rabbitmq", "minio", "flyway", "minio-init"):
+    dependency = services[service_name]["depends_on"]["production-config-check"]
+    assert dependency["condition"] == "service_completed_successfully", service_name
+PY
+printf '%s\n' "Canonical credential alignment checks passed"
+
+run_production_compose run --rm --no-deps production-config-check >/dev/null
+
+printf '%s\n' "Production configuration smoke checks passed"

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -21,3 +21,52 @@ Use this folder for Phase 5 deployment and operations artifacts.
 ## Boundary
 
 Do not put business requirements or implementation code here. Deployment docs should describe how to operate the implemented system.
+
+## Production Credential Preflight
+
+The production overlay must be supplied together with the local baseline:
+
+```bash
+docker compose \
+  --env-file .env.production \
+  -f deploy/docker-compose.yml \
+  -f deploy/docker-compose.prod.yml \
+  config --quiet
+```
+
+Keep `.env.production` outside version control and restrict it to its owner
+(for example, mode `0600` on Linux). Generate independent values rather than
+copying the local template. If a value contains `$`, follow Docker Compose's
+env-file quoting rules so it is not interpolated unexpectedly. The file must
+provide non-empty, non-default values for:
+
+- `POSTGRES_USER`
+- `POSTGRES_PASSWORD`
+- `RABBITMQ_USERNAME`
+- `RABBITMQ_PASSWORD`
+- `MINIO_ACCESS_KEY`
+- `MINIO_SECRET_KEY`
+- `JWT_SECRET`
+
+The production-only `production-config-check` service rejects the published
+development placeholders before PostgreSQL, RabbitMQ, or MinIO can start. It
+reports only the rejected variable name and never its value. Backend, worker,
+Flyway, and initialization services consume the same canonical credentials.
+Starting production with `--no-deps` is unsupported because that option
+explicitly bypasses dependency gates.
+
+The preflight validates the configuration being supplied; it does not rotate
+credentials already stored in initialized service volumes. PostgreSQL and
+other bootstrap credentials must be applied to fresh production volumes or
+changed with an explicit service-specific rotation procedure.
+
+Run the repository regression check before a deployment:
+
+```bash
+sh deploy/tests/production-config-smoke.sh
+```
+
+The script uses synthetic test-only values. It verifies that local Compose
+still accepts its development defaults, missing production values fail during
+configuration, published defaults fail the runtime preflight, and non-default
+values pass.


### PR DESCRIPTION
## What changed

- Add a production-only credential preflight that requires the canonical PostgreSQL, RabbitMQ, MinIO, and JWT variables and rejects blank or published development defaults without logging values.
- Gate PostgreSQL, RabbitMQ, MinIO, Flyway, and MinIO initialization on that preflight.
- Align backend, worker, Flyway, and initialization containers on the same required production credentials while preserving local developer defaults.
- Move Flyway credentials out of command arguments and defer health/init variable expansion to the container.
- Add deterministic negative/positive Compose regression coverage and deployment guidance.

## Why

The production overlay inherited public local placeholders, including a JWT signing value long enough to pass backend validation. Production must fail closed while local Compose remains convenient.

This PR is stacked on #58 because it verifies the corrected Spring Boot/Spring Security baseline.

## Verification

- Backend: `mvn.cmd -B -ntp verify` — 12/12 modules, 68 tests passed.
- Worker: `mvn.cmd -B -ntp verify` — 7/7 modules, 1 test passed.
- POSIX shell syntax: both production check scripts passed `sh -n`.
- `sh deploy/tests/production-config-smoke.sh` passed local config, missing/empty/default rejection, dependency gating, and canonical mapping assertions.
- Real production-overlay runtime smoke passed with synthetic values: configuration preflight, Flyway, MinIO initialization, all long-running container health checks, `/api/v1/health`, and `/actuator/health`.
- `git diff --cached --check` passed before commit.

## Security and scope review

- No real secret or credential is committed; tests use clearly synthetic values.
- Failed checks report variable names only.
- The preflight has no network access.
- Existing initialized volumes still require an explicit service-specific credential rotation procedure; this is documented.
- Redis authentication remains out of scope because it is not part of the frozen contract.
- Frozen requirements and architecture documents are unchanged.
- Self-review found no credential drift, startup-order bypass for the gated infrastructure, or unrelated implementation changes.

Completes Issue #46 when merged after its prerequisite.

## Self-review checklist

- [x] Is the code buildable and runnable?
- [x] Are build/IDE files (like `target/`, `.idea/`, `*.iml`) excluded?
- [x] Is the commit history clean and meaningful?
- [x] Are tests appropriate to the security risk?
- [x] Is the diff limited to Issue #46?