### PR TITLE
[Fix] Refresh post-Sprint-2 project state

### DIFF
--- a/docs/requirements/PROJECTPLAN.md
+++ b/docs/requirements/PROJECTPLAN.md
@@ -89,6 +89,7 @@ See `BACKLOG.md` for detailed sprint backlog with issues, acceptance criteria, d
 
 Phase 3 - Feature Development is active.
 
-- Sprint 1 - Foundation is complete.
-- Sprint 2 - Auth is active.
-- The next implementation batch is Issue 2.1 / GitHub Issue #17 - Backend Auth Service - Registration.
+- Sprint 1 - Foundation and Sprint 2 - Auth are complete.
+- Complete any open P0/P1 security or repository-governance gate before starting another feature batch.
+- Select the next dependency-safe implementation issue from `BACKLOG.md`.
+- GitHub Issues and pull requests are the operational source for the currently active batch.


### PR DESCRIPTION
## What changed

- Update only the mutable `Current Next Step` section in `PROJECTPLAN.md`.
- Record Phase 3 as active and Sprint 1/Foundation plus Sprint 2/Auth as complete.
- Resolve P0/P1 gates that explicitly block the selected feature batch; keep pre-production support and deployment decisions tracked without blocking unrelated feature work.
- Use dependency-safe selection from `BACKLOG.md` and GitHub Issues/PRs as operational batch state.

## Why

The previous text still named Sprint 2 and Issue #17, which could immediately misroute future work. The replacement is durable and avoids a transient issue number.

## Verification

- Exact diff contains only `docs/requirements/PROJECTPLAN.md`.
- `git diff --cached --check` passed before commit.
- No sprint definition, frozen architecture contract, backlog item, or implementation file changed.
- Self-review confirms every acceptance criterion in Issue #47 is represented by the updated section.

Closes #47

## Self-review checklist

- [x] Is the code buildable and runnable? (Documentation-only; no runtime change.)
- [x] Are build/IDE files (like `target/`, `.idea/`, `*.iml`) excluded?
- [x] Is the commit history clean and meaningful?
- [x] Is the diff limited to Issue #47?