### PR TITLE
[Fix] Enforce backend CORS allowlist

### DIFF
--- a/backend/auth/src/main/java/com/vodplatform/auth/config/CorsProperties.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/config/CorsProperties.java
@@ -1,0 +1,85 @@
+package com.vodplatform.auth.config;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "security.cors")
+public record CorsProperties(List<String> allowedOrigins) {
+
+    public CorsProperties {
+        if (allowedOrigins == null
+                || allowedOrigins.isEmpty()
+                || (allowedOrigins.size() == 1
+                        && allowedOrigins.getFirst() != null
+                        && allowedOrigins.getFirst().isBlank())) {
+            allowedOrigins = List.of();
+        } else {
+            Set<String> normalizedOrigins = new LinkedHashSet<>();
+            for (String candidate : allowedOrigins) {
+                String normalizedOrigin = normalizeOrigin(candidate);
+                if (!normalizedOrigins.add(normalizedOrigin)) {
+                    throw new IllegalArgumentException(
+                            "CORS allowed origins must not contain canonical duplicates"
+                    );
+                }
+            }
+            allowedOrigins = List.copyOf(normalizedOrigins);
+        }
+    }
+
+    private static String normalizeOrigin(String candidate) {
+        if (candidate == null || candidate.isBlank()) {
+            throw new IllegalArgumentException("CORS allowed origins must not contain blank entries");
+        }
+
+        URI origin;
+        try {
+            origin = new URI(candidate.trim());
+        } catch (URISyntaxException exception) {
+            throw new IllegalArgumentException("CORS allowed origin is not a valid URI", exception);
+        }
+
+        String scheme = origin.getScheme();
+        if (scheme == null
+                || !(scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))) {
+            throw new IllegalArgumentException("CORS allowed origin must use http or https");
+        }
+        if (origin.isOpaque()
+                || origin.getHost() == null
+                || origin.getRawUserInfo() != null
+                || (origin.getRawPath() != null && !origin.getRawPath().isEmpty())
+                || origin.getRawQuery() != null
+                || origin.getRawFragment() != null) {
+            throw new IllegalArgumentException(
+                    "CORS allowed origin must contain only scheme, host, and optional port"
+            );
+        }
+
+        int port = origin.getPort();
+        if (port == 0 || port > 65_535) {
+            throw new IllegalArgumentException("CORS allowed origin contains an invalid port");
+        }
+
+        String normalizedScheme = scheme.toLowerCase(Locale.ROOT);
+        String normalizedHost = origin.getHost().toLowerCase(Locale.ROOT);
+        if (normalizedHost.contains(":") && !normalizedHost.startsWith("[")) {
+            normalizedHost = "[" + normalizedHost + "]";
+        }
+        int normalizedPort = isDefaultPort(normalizedScheme, port) ? -1 : port;
+
+        return normalizedScheme
+                + "://"
+                + normalizedHost
+                + (normalizedPort == -1 ? "" : ":" + normalizedPort);
+    }
+
+    private static boolean isDefaultPort(String scheme, int port) {
+        return (scheme.equals("http") && port == 80)
+                || (scheme.equals("https") && port == 443);
+    }
+}

--- a/backend/auth/src/main/java/com/vodplatform/auth/config/SecurityConfiguration.java
+++ b/backend/auth/src/main/java/com/vodplatform/auth/config/SecurityConfiguration.java
@@ -3,6 +3,8 @@ package com.vodplatform.auth.config;
 import com.vodplatform.auth.security.AccessTokenAuthenticationConverter;
 import com.vodplatform.auth.security.ApiAccessDeniedHandler;
 import com.vodplatform.auth.security.ApiAuthenticationEntryPoint;
+import java.util.List;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -15,11 +17,28 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration(proxyBeanMethods = false)
 @EnableWebSecurity
 @EnableMethodSecurity
+@EnableConfigurationProperties(CorsProperties.class)
 public class SecurityConfiguration {
+
+    private static final List<String> CORS_ALLOWED_METHODS = List.of(
+            HttpMethod.GET.name(),
+            HttpMethod.POST.name(),
+            HttpMethod.PUT.name(),
+            HttpMethod.DELETE.name(),
+            HttpMethod.OPTIONS.name()
+    );
+    private static final List<String> CORS_ALLOWED_HEADERS = List.of(
+            "Authorization",
+            "Content-Type",
+            "X-Request-ID"
+    );
 
     private static final RequestMatcher PUBLIC_ENDPOINTS = new OrRequestMatcher(
             post("/api/v1/auth/register"),
@@ -33,8 +52,11 @@ public class SecurityConfiguration {
 
     @Bean
     @Order(1)
-    SecurityFilterChain publicEndpointSecurityFilterChain(HttpSecurity http) throws Exception {
-        applyStatelessDefaults(http);
+    SecurityFilterChain publicEndpointSecurityFilterChain(
+            HttpSecurity http,
+            CorsConfigurationSource corsConfigurationSource
+    ) throws Exception {
+        applyStatelessDefaults(http, corsConfigurationSource);
         http.securityMatcher(PUBLIC_ENDPOINTS)
                 .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll());
         return http.build();
@@ -46,9 +68,10 @@ public class SecurityConfiguration {
             HttpSecurity http,
             ApiAuthenticationEntryPoint authenticationEntryPoint,
             ApiAccessDeniedHandler accessDeniedHandler,
-            AccessTokenAuthenticationConverter authenticationConverter
+            AccessTokenAuthenticationConverter authenticationConverter,
+            CorsConfigurationSource corsConfigurationSource
     ) throws Exception {
-        applyStatelessDefaults(http);
+        applyStatelessDefaults(http, corsConfigurationSource);
         http.authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
                 .exceptionHandling(exceptions -> exceptions
                         .authenticationEntryPoint(authenticationEntryPoint)
@@ -59,8 +82,26 @@ public class SecurityConfiguration {
         return http.build();
     }
 
-    private void applyStatelessDefaults(HttpSecurity http) throws Exception {
-        http.csrf(csrf -> csrf.disable())
+    @Bean
+    CorsConfigurationSource corsConfigurationSource(CorsProperties properties) {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(properties.allowedOrigins());
+        configuration.setAllowedMethods(CORS_ALLOWED_METHODS);
+        configuration.setAllowedHeaders(CORS_ALLOWED_HEADERS);
+        configuration.setAllowCredentials(false);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/v1/**", configuration);
+        source.registerCorsConfiguration("/hls/**", configuration);
+        return source;
+    }
+
+    private void applyStatelessDefaults(
+            HttpSecurity http,
+            CorsConfigurationSource corsConfigurationSource
+    ) throws Exception {
+        http.cors(cors -> cors.configurationSource(corsConfigurationSource))
+                .csrf(csrf -> csrf.disable())
                 .requestCache(requestCache -> requestCache.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .formLogin(formLogin -> formLogin.disable())

--- a/backend/auth/src/test/java/com/vodplatform/auth/config/CorsPropertiesTest.java
+++ b/backend/auth/src/test/java/com/vodplatform/auth/config/CorsPropertiesTest.java
@@ -1,0 +1,98 @@
+package com.vodplatform.auth.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+
+class CorsPropertiesTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(TestConfiguration.class);
+
+    @Test
+    void bindsCommaSeparatedOriginsAndNormalizesCanonicalForm() {
+        contextRunner.withPropertyValues(
+                        "security.cors.allowed-origins="
+                                + "HTTP://LOCALHOST:80,"
+                                + "https://EXAMPLE.com:443,"
+                                + "https://api.example.com:8443"
+                )
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(CorsProperties.class);
+                    assertThat(context.getBean(CorsProperties.class).allowedOrigins())
+                            .containsExactly(
+                                    "http://localhost",
+                                    "https://example.com",
+                                    "https://api.example.com:8443"
+                            );
+                });
+    }
+
+    @Test
+    void missingOrSingleBlankValueProducesAnEmptyImmutableAllowlist() {
+        CorsProperties missing = new CorsProperties(null);
+        CorsProperties blank = new CorsProperties(List.of("   "));
+
+        assertThat(missing.allowedOrigins()).isEmpty();
+        assertThat(blank.allowedOrigins()).isEmpty();
+        assertThatThrownBy(() -> missing.allowedOrigins().add("https://example.com"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "*",
+            "ftp://example.com",
+            "https://user:password@example.com",
+            "https://example.com/path",
+            "https://example.com?query=value",
+            "https://example.com#fragment",
+            "https://example.com:0",
+            "https://example.com:70000",
+            "https://exa mple.com"
+    })
+    void rejectsUnsafeOrInvalidOrigin(String origin) {
+        assertThatThrownBy(() -> new CorsProperties(List.of(origin)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void rejectsBlankEntriesInsideConfiguredList() {
+        assertThatThrownBy(() -> new CorsProperties(List.of(
+                "https://one.example.com",
+                " ",
+                "https://two.example.com"
+        ))).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("blank");
+    }
+
+    @Test
+    void rejectsNullEntriesWithAConfigurationError() {
+        assertThatThrownBy(() -> new CorsProperties(Collections.singletonList(null)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("blank");
+    }
+
+    @Test
+    void rejectsDuplicatesAfterCanonicalNormalization() {
+        assertThatThrownBy(() -> new CorsProperties(List.of(
+                "HTTPS://EXAMPLE.com:443",
+                "https://example.com"
+        ))).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("duplicates");
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties(CorsProperties.class)
+    static class TestConfiguration {
+    }
+}

--- a/backend/common/src/main/resources/application.yml
+++ b/backend/common/src/main/resources/application.yml
@@ -11,6 +11,10 @@ auth:
     access-token-ttl: ${JWT_ACCESS_TOKEN_TTL_MINUTES:60}m
     refresh-token-ttl: ${JWT_REFRESH_TOKEN_TTL_DAYS:7}d
 
+security:
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:}
+
 management:
   endpoints:
     web:

--- a/backend/common/src/test/java/com/vodplatform/common/CorsSecurityIntegrationTests.java
+++ b/backend/common/src/test/java/com/vodplatform/common/CorsSecurityIntegrationTests.java
@@ -1,0 +1,166 @@
+package com.vodplatform.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest(
+        properties = {
+                "auth.tokens.secret=test-only-secret-with-at-least-32-bytes",
+                "auth.tokens.access-token-ttl=15m",
+                "auth.tokens.refresh-token-ttl=7d",
+                "CORS_ALLOWED_ORIGINS=https://app.example.test"
+        }
+)
+@AutoConfigureMockMvc
+class CorsSecurityIntegrationTests {
+
+    private static final String ALLOWED_ORIGIN = "https://app.example.test";
+    private static final String DISALLOWED_ORIGIN = "https://untrusted.example.test";
+    private static final List<String> ALLOWED_METHODS = List.of(
+            "GET",
+            "POST",
+            "PUT",
+            "DELETE",
+            "OPTIONS"
+    );
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void allowedPreflightRunsBeforeAuthenticationForPublicProtectedAndHlsPaths() throws Exception {
+        assertAllowedPreflight(
+                "/api/v1/auth/login",
+                "POST",
+                List.of("Content-Type", "X-Request-ID")
+        );
+        assertAllowedPreflight(
+                "/api/v1/users/me",
+                "GET",
+                List.of("Authorization")
+        );
+        assertAllowedPreflight(
+                "/hls/video-assets/00000000-0000-0000-0000-000000000000/master.m3u8",
+                "GET",
+                List.of("Authorization", "X-Request-ID")
+        );
+    }
+
+    @Test
+    void disallowedOriginMethodAndHeaderReceiveNoCorsAuthorization() throws Exception {
+        assertRejectedPreflight(
+                "/api/v1/auth/login",
+                DISALLOWED_ORIGIN,
+                "POST",
+                "Content-Type"
+        );
+        assertRejectedPreflight(
+                "/api/v1/auth/login",
+                ALLOWED_ORIGIN,
+                "PATCH",
+                "Content-Type"
+        );
+        assertRejectedPreflight(
+                "/api/v1/auth/login",
+                ALLOWED_ORIGIN,
+                "POST",
+                "X-Unsafe-Header"
+        );
+    }
+
+    @Test
+    void actualCrossOriginRequestsPreservePublicAndUnauthorizedBehavior() throws Exception {
+        mockMvc.perform(get("/api/v1/health")
+                        .header(HttpHeaders.ORIGIN, ALLOWED_ORIGIN))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, ALLOWED_ORIGIN))
+                .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS));
+
+        mockMvc.perform(get("/api/v1/users/me")
+                        .header(HttpHeaders.ORIGIN, ALLOWED_ORIGIN))
+                .andExpect(status().isUnauthorized())
+                .andExpect(header().string(HttpHeaders.WWW_AUTHENTICATE, "Bearer"))
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, ALLOWED_ORIGIN))
+                .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS));
+    }
+
+    @Test
+    void sameOriginAndNonCorsPathsRemainUnchanged() throws Exception {
+        mockMvc.perform(get("/api/v1/health"))
+                .andExpect(status().isOk())
+                .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
+
+        mockMvc.perform(get("/api/v1/users/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(header().string(HttpHeaders.WWW_AUTHENTICATE, "Bearer"))
+                .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
+
+        mockMvc.perform(get("/actuator/health")
+                        .header(HttpHeaders.ORIGIN, ALLOWED_ORIGIN))
+                .andExpect(status().isOk())
+                .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
+    }
+
+    private void assertAllowedPreflight(
+            String path,
+            String method,
+            List<String> requestedHeaders
+    ) throws Exception {
+        MvcResult result = mockMvc.perform(options(path)
+                        .header(HttpHeaders.ORIGIN, ALLOWED_ORIGIN)
+                        .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, method)
+                        .header(
+                                HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS,
+                                String.join(",", requestedHeaders)
+                        ))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, ALLOWED_ORIGIN))
+                .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS))
+                .andExpect(header().doesNotExist(HttpHeaders.WWW_AUTHENTICATE))
+                .andReturn();
+
+        assertThat(csvHeader(result, HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
+                .containsExactlyElementsOf(ALLOWED_METHODS);
+        assertThat(csvHeader(result, HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS))
+                .map(String::toLowerCase)
+                .containsExactlyElementsOf(requestedHeaders.stream()
+                        .map(String::toLowerCase)
+                        .toList());
+    }
+
+    private void assertRejectedPreflight(
+            String path,
+            String origin,
+            String method,
+            String requestedHeaders
+    ) throws Exception {
+        mockMvc.perform(options(path)
+                        .header(HttpHeaders.ORIGIN, origin)
+                        .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, method)
+                        .header(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, requestedHeaders))
+                .andExpect(status().isForbidden())
+                .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .andExpect(header().doesNotExist(HttpHeaders.WWW_AUTHENTICATE));
+    }
+
+    private List<String> csvHeader(MvcResult result, String headerName) {
+        String value = result.getResponse().getHeader(headerName);
+        assertThat(value).isNotNull();
+        return Arrays.stream(value.split(","))
+                .map(String::trim)
+                .toList();
+    }
+}

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -77,6 +77,7 @@ services:
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER:?Set a non-default production PostgreSQL username}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:?Set a non-default production PostgreSQL password}
       JWT_SECRET: ${JWT_SECRET:?Set a non-default production JWT signing secret}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
       RABBITMQ_USERNAME: ${RABBITMQ_USERNAME:?Set a non-default production RabbitMQ username}
       RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD:?Set a non-default production RabbitMQ password}
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:?Set a non-default production MinIO access key}

--- a/deploy/tests/production-config-smoke.sh
+++ b/deploy/tests/production-config-smoke.sh
@@ -85,6 +85,7 @@ run_production_compose() {
   MINIO_ACCESS_KEY="$minio_access_key_value" \
   MINIO_SECRET_KEY="$minio_secret_key_value" \
   JWT_SECRET="$jwt_secret_value" \
+  CORS_ALLOWED_ORIGINS= \
     docker compose \
       -p "$compose_project" \
       -f deploy/docker-compose.yml \
@@ -101,6 +102,7 @@ run_production_compose_from_file() {
     -u MINIO_ACCESS_KEY \
     -u MINIO_SECRET_KEY \
     -u JWT_SECRET \
+    -u CORS_ALLOWED_ORIGINS \
     docker compose \
       --env-file "$env_file" \
       -p "$compose_project" \
@@ -262,6 +264,7 @@ expected = {
         "SPRING_DATASOURCE_USERNAME": "ci_postgres_user",
         "SPRING_DATASOURCE_PASSWORD": "ci-postgres-password-46",
         "JWT_SECRET": "ci-jwt-signing-secret-with-at-least-thirty-two-bytes",
+        "CORS_ALLOWED_ORIGINS": "",
         "RABBITMQ_USERNAME": "ci_rabbitmq_user",
         "RABBITMQ_PASSWORD": "ci-rabbitmq-password-46",
         "MINIO_ACCESS_KEY": "ci_minio_access_key",


### PR DESCRIPTION
## What
- Bind the backend CORS allowlist from CORS_ALLOWED_ORIGINS through validated configuration properties.
- Apply CORS only to /api/v1/** and /hls/** in both Spring Security filter chains.
- Allow the frozen GET, POST, PUT, DELETE, OPTIONS methods and Authorization, Content-Type, X-Request-ID headers without credentialed browser requests.
- Forward the optional allowlist in the production overlay and keep production config checks deterministic.
- Add unit and integration regression coverage for normalization, invalid origins, public/protected/HLS preflights, rejections, same-origin behavior, and actuator isolation.

## Why
The frozen security requirements call for an environment-driven CORS allowlist, but the backend did not consume the exposed CORS_ALLOWED_ORIGINS setting. This change makes cross-origin behavior explicit and fail-closed while preserving same-origin production behavior.

## Verification
- Final auth/user/common suite: 91 tests passed.
- Full backend reactor: 12/12 modules passed on the production implementation.
- Production configuration smoke and shell syntax checks passed.
- Isolated ten-service Compose stack reached healthy state.
- Runtime checks through Nginx passed for allowed public, protected, and frozen HLS preflights; untrusted origins, PATCH, and unsafe headers returned 403; public health remained 200 and unauthenticated profile remained 401 Bearer.
- Three-dot diff against the parent contains only the seven Issue #48 files.
- git diff --check passed.

## Self-review
- [x] Is the code buildable and runnable?
- [x] Are build/IDE files (like target/, .idea/, *.iml) excluded?
- [x] Is the commit history clean and meaningful?
- [x] Security scope and source-of-truth identifiers were reviewed.
- [x] No frozen architecture or API contract was modified.

Closes #48