### PR TITLE
[Fix] Upgrade pgJDBC for CVE-2026-54291

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -34,5 +34,6 @@
     <properties>
         <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <postgresql.version>42.7.13</postgresql.version>
     </properties>
 </project>


### PR DESCRIPTION
## What
- override Spring Boot's managed `postgresql.version` from 42.7.11 to 42.7.13
- keep the version override in the backend parent so the runtime dependency remains coherently managed

## Why
- pgJDBC 42.7.11 is affected by CVE-2026-54291 / GHSA-j92g-9f8w-j867
- 42.7.13 is the current upstream patched release
- Spring Boot 3.5.16 still manages 42.7.11, so this narrow standard property override is required

Closes #62

## Verification
- backend Maven reactor: 12/12 modules successful; 91 tests passed
- dependency tree: exactly `org.postgresql:postgresql:42.7.13:runtime`
- packaged application JAR and Docker image: exactly `postgresql-42.7.13.jar`
- isolated 10-service Compose runtime: application services healthy; Flyway and MinIO init exited 0
- Flyway: 3 successful migrations, 0 failures; schema counts 15 tables / 30 indexes / 53 constraints / 17 foreign keys / 9 checks
- Nginx runtime flow: health 200, registration 201, login 200 with access/refresh tokens present, persisted user ACTIVE
- backend runtime logs: Hikari established `org.postgresql.jdbc.PgConnection`; no SQL/pool errors
- Trivy 0.72.0 with current Java DB: packaged `postgresql-42.7.13.jar` and all backend image JARs report 0 HIGH/CRITICAL findings
- `git diff --check`: clean

## Scope
- no API, schema, migration, frozen documentation, or application behavior changes
- no TLS/channel-binding deployment changes; those are outside this dependency remediation

## Self-review
- [x] Is the code buildable and runnable?
- [x] Are build/IDE files (like target/, .idea/, *.iml) excluded?
- [x] Is the commit history clean and meaningful?
- [x] Dependency management remains centralized and the diff is one focused line
- [x] Security threshold and test assertions were not weakened