### PR TITLE
[Fix] Harden CI dependency security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+
+updates:
+  - package-ecosystem: maven
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Asia/Bangkok
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: maven
+    directory: /worker
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:15"
+      timezone: Asia/Bangkok
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:30"
+      timezone: Asia/Bangkok
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:45"
+      timezone: Asia/Bangkok
+    open-pull-requests-limit: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ name: CI
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   backend-build:
     name: Backend Maven build and test
@@ -13,10 +16,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
           java-version: "21"
@@ -32,10 +37,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
           java-version: "21"
@@ -51,7 +58,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Verify production configuration fails closed
         run: sh deploy/tests/production-config-smoke.sh
@@ -80,10 +89,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: npm
@@ -100,6 +111,7 @@ jobs:
       - name: Build frontend
         working-directory: frontend
         run: npm run build
+
   schema-migration:
     name: Flyway schema migration
     runs-on: ubuntu-latest
@@ -121,7 +133,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Apply Flyway migration
         run: >-

--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -1,0 +1,93 @@
+name: Dependency security
+
+"on":
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/**/pom.xml"
+      - "worker/**/pom.xml"
+      - frontend/package.json
+      - frontend/package-lock.json
+      - .github/workflows/ci.yml
+      - .github/workflows/dependency-security.yml
+      - .github/dependabot.yml
+  pull_request:
+    paths:
+      - "backend/**/pom.xml"
+      - "worker/**/pom.xml"
+      - frontend/package.json
+      - frontend/package-lock.json
+      - .github/workflows/ci.yml
+      - .github/workflows/dependency-security.yml
+      - .github/dependabot.yml
+  schedule:
+    - cron: "17 20 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-security-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  dependency-audit:
+    name: Production dependency vulnerability audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Java
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Package backend runtime dependencies
+        working-directory: backend
+        run: mvn -B -ntp package -DskipTests
+
+      - name: Package worker runtime dependencies
+        working-directory: worker
+        run: mvn -B -ntp package -DskipTests
+
+      - name: Stage executable Maven artifacts
+        run: |
+          mkdir -p .dependency-security/runtime
+          cp backend/common/target/common-0.1.0-SNAPSHOT.jar .dependency-security/runtime/backend.jar
+          cp worker/queue/target/queue-0.1.0-SNAPSHOT.jar .dependency-security/runtime/worker.jar
+
+      - name: Audit production npm dependencies
+        working-directory: frontend
+        run: npm audit --package-lock-only --omit=dev --audit-level=high
+
+      - name: Scan production library dependencies
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_OFFLINE_SCAN: "true"
+        with:
+          version: v0.74.0
+          scan-type: rootfs
+          scan-ref: .dependency-security/runtime
+          scanners: vuln
+          vuln-type: library
+          severity: HIGH,CRITICAL
+          ignore-unfixed: false
+          exit-code: "1"
+          format: table
+          timeout: 10m

--- a/docs/testing/DEPENDENCY-SECURITY.md
+++ b/docs/testing/DEPENDENCY-SECURITY.md
@@ -1,0 +1,36 @@
+# Dependency Security
+
+## Automated Policy
+
+The dependency-security workflow applies two complementary production-dependency gates:
+
+- `npm audit --package-lock-only --omit=dev --audit-level=high` fails on high or critical production npm advisories without installing packages or running lifecycle scripts.
+- Trivy scans the packaged backend and worker executable JARs for high or critical library vulnerabilities. The workflow stages the same `common-0.1.0-SNAPSHOT.jar` and `queue-0.1.0-SNAPSHOT.jar` artifacts copied into the runtime images, then uses a root-filesystem scan so ignored Maven `target/` directories cannot make the gate silently fall back to manifest-only coverage.
+
+The gates report findings without applying dependency upgrades. Any suppression requires a dedicated issue with evidence that the advisory is not applicable.
+
+## Reviewed Baseline Advisories
+
+As of 2026-08-29, `npm audit --omit=dev` reports two moderate advisories through `react-router-dom` 6.30.6:
+
+- `GHSA-wrjc-x8rr-h8h6` — open redirect behavior involving backslashes.
+- `GHSA-337j-9hxr-rhxg` — constructor injection in server-side hydration error deserialization.
+
+They remain visible and tracked by GitHub Issue #56. The available npm remediation is a forced React Router 7 major upgrade, so this hardening batch does not apply it automatically. High and critical findings still fail CI.
+
+## Automated Update Visibility
+
+Dependabot checks backend Maven, worker Maven, frontend npm, and GitHub Actions weekly. Each ecosystem is limited to one open version-update pull request, and no auto-merge is configured.
+
+Dependabot updates the SHA-pinned action references, but it does not own the explicit Trivy CLI `version` input. Review that scanner version separately whenever the Trivy action or the scheduled security baseline is updated.
+
+The Dependency Review action is intentionally absent until a repository administrator enables and verifies the GitHub Dependency Graph and its dependency-review API. Dependabot alerts and security updates are separate recommended repository settings, not technical prerequisites for the action. Adding a review action before the graph/API prerequisite is available would create a misleading or permanently failing check.
+
+## Local Checks
+
+```bash
+cd frontend
+npm audit --package-lock-only --omit=dev --audit-level=high
+```
+
+The Trivy gate is defined in `.github/workflows/dependency-security.yml` and scans the executable Maven artifacts produced by the same Java 21 build used in CI. It runs when dependency manifests or security automation change and on a weekly schedule, so unrelated source-only pull requests do not repeat external advisory downloads.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -11,6 +11,10 @@ Use this folder for Phase 4 testing and hardening artifacts.
 - known limitations
 - test evidence index
 
+## Current Hardening Guides
+
+- [Dependency security](DEPENDENCY-SECURITY.md)
+
 ## Purpose
 
 - prove the upload -> transcode -> playback flow


### PR DESCRIPTION
## What changed  - Set explicit read-only workflow token permissions and disable checkout credential persistence. - Pin checkout, Java, Node, and Trivy actions to immutable release commit SHAs. - Add a scheduled and dependency-change-triggered security workflow that packages the backend and worker, stages the exact executable JARs used by their Docker images, gates HIGH/CRITICAL library findings with Trivy v0.74.0, and gates HIGH/CRITICAL production npm findings. - Add bounded weekly Dependabot visibility for backend Maven, worker Maven, frontend npm, and GitHub Actions without auto-merge. - Document thresholds, the reviewed React Router moderate baseline, scanner maintenance, and the Dependency Graph/API prerequisite for Dependency Review.  ## Why  Issue #49 requires repository-level least privilege and repeatable dependency-security visibility. The initial scanner trial identified the pgJDBC advisory addressed by prerequisite Issue #62, so this PR is intentionally stacked on that corrected baseline. Root-filesystem scanning is used for the staged Spring Boot executable JARs because a repository filesystem scan did not traverse Git-ignored Maven target artifacts.  ## Earlier baseline verification  - actionlint 1.7.12: both workflows pass. - Every action tag was resolved through the GitHub API and matches the pinned 40-character commit SHA; all 6 checkout steps use persist-credentials: false. - npm production audit: exit 0 at HIGH threshold; two known Moderate React Router advisories remain visible under Issue #56. - Trivy v0.74.0 archive checksum matched the official release checksum; rootfs scan of backend.jar and worker.jar found 0 HIGH/CRITICAL vulnerabilities. - Backend reactor: 12/12 modules pass, 91 tests pass. - Worker reactor: 7/7 modules pass, 1 test passes. - Frontend: 86 tests pass and production build succeeds. - git diff --check: pass.  ## Scope and limitations  - No application code or frozen requirement/architecture contract changes. - Dependency Review is not added while the repository Dependency Graph/review API is unavailable; Dependabot alerts are a separate repository setting. - Container OS/non-root/digest hardening remains tracked separately. - This PR must be reviewed and merged only after its prerequisite stack through Issue #62.  ## Self-review checklist  - [x] Is the code buildable and runnable? - [x] Are build/IDE files (like target/, .idea/, *.iml) excluded? - [x] Is the commit history clean and meaningful? - [x] Reviewed least privilege, immutable references, scanner failure thresholds, cache/network behavior, false-positive handling, and focused scope.   ## Closeout verification (2026-09-17) A fresh scan exposed three Tomcat advisories in both runtime JARs. Prerequisite #58 now pins the released Tomcat 10.1.59 patch in both reactors; the subsequent runtime scan passes with zero HIGH/CRITICAL findings (run 35195269508). Both npm Moderate findings remain visible under #56. The complete prerequisite stack is now merged into main, and this PR contains only the five CI/security-documentation files. Updated-head CI and dependency security checks both passed before merge.  Closes #49  

## Merged-main verification
- Main d12425e: CI passed (91 backend, 1 worker, 86 frontend tests): https://github.com/Duyphanb/Self-hosted-VoD-Platform/actions/runs/35220942520 .
- Main dependency audit passed without weakening thresholds: https://github.com/Duyphanb/Self-hosted-VoD-Platform/actions/runs/35221165442 .
- Isolated local auth stack: Newman 11 requests / 28 assertions and eight browser smoke checks passed; three Flyway migrations applied; all eight long-running services healthy.
- Local worker smoke reused an existing Java/FFmpeg image base with the newly built main JAR because Ubuntu downloads were slow. Its Boot 3.5.16 and Tomcat 10.1.59 contents were verified; CI separately built the repository Dockerfile. This does not verify an encoding pipeline: queue consumption remains disabled in the current skeleton.
